### PR TITLE
[Bug] Fix Test Runner w/ CRLF Enforcement

### DIFF
--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -56,6 +56,7 @@ class TestCase:
     def __str__(self) -> str:
         s = f"{self.method} {self.path} {self.http_ver}\r\n"
         s += "\r\n".join(f"{k}: {v}" for k, v in self.headers.items())
+        s += "\r\n"
         return s
 
 cases = [


### PR DESCRIPTION
## About
After enforcing CRLF per RFC 2616 guidelines, the test runner broke since it wasn't properly appending an extra CRLF to mark where the body begins in the request. This patch fixes this issue.