### PR TITLE
[Feature] Rebuild Binaries When Bundling Release

### DIFF
--- a/build_tools/build_release.sh
+++ b/build_tools/build_release.sh
@@ -4,6 +4,9 @@ set -e
 # CD into project directory
 cd "$(dirname "$0")/../"
 
+# Rebuild binaries
+make -B
+
 if [ -d "temp_release" ]; then
     rm -rf temp_release
 fi


### PR DESCRIPTION
## About
Per #18, this patch should improve the way that releases are bundled in the sense that the Mercury binaries are rebuilt each time a release is generated to make sure the most recent changes are zipped together.

I'll need to test this on my personal laptop later tonight but this quick fix should do the job.

Closes #18.