### PR TITLE
[Feature] Add .gitattributes File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*           text=auto
+*.sh		text eol=lf


### PR DESCRIPTION
## About
I've added a .gitattributes file to enforce line endings across environments for shell scripts. This can be expanded upon for future releases.

## Fix
If the line endings do not transfer properly, remove their cached properties and renormalize the entire file structure of the repository.

```
git rm --cached -r .
git reset --hard
git add .
```

Note: ensure there are no uncommitted changes, otherwise they will be undone.
Closes #23