### PR TITLE
[Docs] Add Section Hyperlink to TLS Certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [About](#about)
 - [Build Info](#build-info)
     - [Linux & Windows Builds](#linux--windows-builds)
+    - [TLS Certs](#tls-certs)
 - [Changelog](#changelog)
 - [Credits](#credits)
 


### PR DESCRIPTION
## About
I've updated the README's Table of Contents to add a hyperlink to the TLS Certs section under the Linux & Windows builds.