### PR TITLE
[Feature] Expand Configuration File & File Linking Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v0.7.6
 - Add support for toggling directory index listings in config file Match nodes
 - Can now toggle IPv4 & IPv6 independently in config file
+- Now explicitly rejects accessing symlinked content
+    - Symlinking the document root itself is still allowed
+    - Note than an Internal Server Error (500) may occur if attempting to access Linux symlinks on Windows
 
 ## v0.7.5
 - Add support for HTTP/1.0 ([#16](https://github.com/travis-heavener/mercury/issues/16))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.7.6
+- Add support for toggling directory index listings in Match nodes
+
 ## v0.7.5
 - Add support for HTTP/1.0 ([#16](https://github.com/travis-heavener/mercury/issues/16))
 - Normalized response header plaintext formatting (ex. cOntENt-LeNGTh --> Content-Length)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## v0.7.6
-- Add support for toggling directory index listings in Match nodes
+- Add support for toggling directory index listings in config file Match nodes
+- Can now toggle IPv4 & IPv6 independently in config file
 
 ## v0.7.5
 - Add support for HTTP/1.0 ([#16](https://github.com/travis-heavener/mercury/issues/16))

--- a/conf/default/mercury.conf
+++ b/conf/default/mercury.conf
@@ -6,10 +6,25 @@
     <DocumentRoot> ./public/ </DocumentRoot>
 
     #
-    # Specifies what port will be used to serve content
+    # Specifies what port will be used to serve cleartext (non-HTTPS) content
     #   Default: 80
     #
     <Port> 80 </Port>
+
+    #
+    # Specifies which port to serve SSL/TLS traffic on, or "off" if disabled
+    # See ./conf/ssl/cert.pem and ./conf/ssl/key.pem
+    #   Default: off
+    #
+    <TLSPort> off </TLSPort>
+
+    #
+    # Enables or disables IPv4 and IPv6 traffic (either "on" or "off")
+    #   IPv4 Default: on
+    #   IPv6 Default: off
+    #
+    <EnableIPv4> on </EnableIPv4>
+    <EnableIPv6> off </EnableIPv6>
 
     #
     # Specifies what name for index files will be served when accessing a directory by name
@@ -18,25 +33,28 @@
     <IndexFile> index.html </IndexFile>
 
     #
-    # Specifies where server access logs are stored
-    #   Default: ./logs/access.log
+    # Specifies where server access & error logs are stored
+    #   Access Default: ./logs/access.log
+    #   Error Default: ./logs/error.log
     #
     <AccessLogFile> ./logs/access.log </AccessLogFile>
-
-    #
-    # Specifies where server error logs are stored
-    #   Default: ./logs/error.log
-    #
     <ErrorLogFile> ./logs/error.log </ErrorLogFile>
 
     #
     # Match allows individual file/directory control over resource access via regex matches
     #
-    <Match pattern=".*\.html">
+    <Match pattern=".*">
         #
         # Allows HTTP response headers to be set, only valid within a Match
         #
-        <Header name="Cache-Control"> public, must-revalidate, max-age=3600 </Header>
+        <Header name="Cache-Control"> public, must-revalidate, max-age=300 </Header>
+
+        #
+        # Enables or disables directory index listings, only valid within a Match (either "on" or "off").
+        # Only the first ShowDirectoryIndexes node will be recognized.
+        #   Default: on
+        #
+        <ShowDirectoryIndexes> on </ShowDirectoryIndexes>
     </Match>
 
     #
@@ -50,11 +68,4 @@
     #   Default: 16384
     #
     <MaxRequestBuffer> 16384 </MaxRequestBuffer>
-
-    #
-    # Specifies which port to serve SSL/TLS traffic on, or "off" if disabled
-    # See ./conf/ssl/cert.pem and ./conf/ssl/key.pem
-    #   Default: off
-    #
-    <TLSPort> off </TLSPort>
 </Mercury>

--- a/conf/mercury.conf
+++ b/conf/mercury.conf
@@ -3,7 +3,7 @@
     # Specifies where files are served from
     #   Default: ./public/
     #
-    <DocumentRoot> ../GitHub Pages/ </DocumentRoot>
+    <DocumentRoot> ./public/ </DocumentRoot>
 
     #
     # Specifies what port will be used to serve cleartext (non-HTTPS) content

--- a/conf/mercury.conf
+++ b/conf/mercury.conf
@@ -3,7 +3,7 @@
     # Specifies where files are served from
     #   Default: ./public/
     #
-    <DocumentRoot> ./public/ </DocumentRoot>
+    <DocumentRoot> ./public/win/soft </DocumentRoot>
 
     #
     # Specifies what port will be used to serve cleartext (non-HTTPS) content

--- a/conf/mercury.conf
+++ b/conf/mercury.conf
@@ -3,10 +3,10 @@
     # Specifies where files are served from
     #   Default: ./public/
     #
-    <DocumentRoot> ./public/ </DocumentRoot>
+    <DocumentRoot> ../GitHub Pages/ </DocumentRoot>
 
     #
-    # Specifies what port will be used to serve content
+    # Specifies what port will be used to serve cleartext (non-HTTPS) content
     #   Default: 80
     #
     <Port> 80 </Port>
@@ -18,15 +18,11 @@
     <IndexFile> index.html </IndexFile>
 
     #
-    # Specifies where server access logs are stored
-    #   Default: ./logs/access.log
+    # Specifies where server access & error logs are stored
+    #   Access Default: ./logs/access.log
+    #   Error Default: ./logs/error.log
     #
     <AccessLogFile> ./logs/access.log </AccessLogFile>
-
-    #
-    # Specifies where server error logs are stored
-    #   Default: ./logs/error.log
-    #
     <ErrorLogFile> ./logs/error.log </ErrorLogFile>
 
     #
@@ -37,6 +33,13 @@
         # Allows HTTP response headers to be set, only valid within a Match
         #
         <Header name="Cache-Control"> public, must-revalidate, max-age=300 </Header>
+
+        #
+        # Enables or disables directory index listings, only valid within a Match.
+        # Only the first ShowDirectoryIndexes node will be recognized.
+        #   Values: on | off
+        #
+        <ShowDirectoryIndexes> on </ShowDirectoryIndexes>
     </Match>
 
     #

--- a/conf/mercury.conf
+++ b/conf/mercury.conf
@@ -12,6 +12,21 @@
     <Port> 80 </Port>
 
     #
+    # Specifies which port to serve SSL/TLS traffic on, or "off" if disabled
+    # See ./conf/ssl/cert.pem and ./conf/ssl/key.pem
+    #   Default: off
+    #
+    <TLSPort> 443 </TLSPort>
+
+    #
+    # Enables or disables IPv4 and IPv6 traffic (either "on" or "off")
+    #   IPv4 Default: on
+    #   IPv6 Default: off
+    #
+    <EnableIPv4> on </EnableIPv4>
+    <EnableIPv6> on </EnableIPv6>
+
+    #
     # Specifies what name for index files will be served when accessing a directory by name
     #   Default: index.html
     #
@@ -35,9 +50,9 @@
         <Header name="Cache-Control"> public, must-revalidate, max-age=300 </Header>
 
         #
-        # Enables or disables directory index listings, only valid within a Match.
+        # Enables or disables directory index listings, only valid within a Match (either "on" or "off").
         # Only the first ShowDirectoryIndexes node will be recognized.
-        #   Values: on | off
+        #   Default: on
         #
         <ShowDirectoryIndexes> on </ShowDirectoryIndexes>
     </Match>
@@ -53,11 +68,4 @@
     #   Default: 16384
     #
     <MaxRequestBuffer> 16384 </MaxRequestBuffer>
-
-    #
-    # Specifies which port to serve SSL/TLS traffic on, or "off" if disabled
-    # See ./conf/ssl/cert.pem and ./conf/ssl/key.pem
-    #   Default: off
-    #
-    <TLSPort> 443 </TLSPort>
 </Mercury>

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -93,6 +93,10 @@ int loadConfig() {
         // Handle std::filesystem::canonical failure
         std::cerr << "Failed to parse config file, DocumentRoot points to invalid/nonexistant directory.\n";
         return CONF_FAILURE;
+    } catch (std::runtime_error&) {
+        // Handle canonical failure from IO error
+        std::cerr << "Failed to parse config file, DocumentRoot points to invalid/nonexistant directory.\n";
+        return CONF_FAILURE;
     }
 
     /************************** Extract Port **************************/

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -8,6 +8,8 @@ namespace conf {
 
     std::filesystem::path DOCUMENT_ROOT;
     port_t PORT;
+    bool IS_IPV4_ENABLED;
+    bool IS_IPV6_ENABLED;
     unsigned short MAX_REQUEST_BACKLOG;
     unsigned int MAX_REQUEST_BUFFER;
     std::vector<conf::Match*> matchConfigs;
@@ -101,6 +103,47 @@ int loadConfig() {
     }
 
     PORT = portNode.text().as_uint();
+
+    /************************** Extract IPv4 toggle **************************/
+    pugi::xml_node ipv4Node = root.child("EnableIPv4");
+    if (!ipv4Node) {
+        std::cerr << "Failed to parse config file, missing EnableIPv4 node.\n";
+        return CONF_FAILURE;
+    }
+
+    std::string ipv4StatusStr = ipv4Node.text().as_string();
+    trimString(ipv4StatusStr);
+
+    // Verify valid value provided
+    if (ipv4StatusStr != "on" && ipv4StatusStr != "off") {
+        std::cerr << "Failed to parse config file, invalid value for EnableIPv4.\n";
+        return CONF_FAILURE;
+    }
+
+    IS_IPV4_ENABLED = ipv4StatusStr == "on";
+
+    /************************** Extract IPv6 toggle **************************/
+    pugi::xml_node ipv6Node = root.child("EnableIPv6");
+    if (!ipv6Node) {
+        std::cerr << "Failed to parse config file, missing EnableIPv6 node.\n";
+        return CONF_FAILURE;
+    }
+
+    std::string ipv6StatusStr = ipv6Node.text().as_string();
+    trimString(ipv6StatusStr);
+
+    // Verify valid value provided
+    if (ipv6StatusStr != "on" && ipv6StatusStr != "off") {
+        std::cerr << "Failed to parse config file, invalid value for EnableIPv6.\n";
+        return CONF_FAILURE;
+    }
+
+    IS_IPV6_ENABLED = ipv6StatusStr == "on";
+
+    if (!IS_IPV4_ENABLED && !IS_IPV6_ENABLED) {
+        std::cerr << "Either IPv4 or IPv6 must be enabled in the config file!\n";
+        return CONF_FAILURE;
+    }
 
     /************************** Extract IndexFile **************************/
     pugi::xml_node indexFileNode = root.child("IndexFile");

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -79,7 +79,7 @@ int loadConfig() {
 
     // Resolve as absolute path
     try {
-        DOCUMENT_ROOT = std::filesystem::canonical(DOCUMENT_ROOT);
+        DOCUMENT_ROOT = resolveCanonicalPath(DOCUMENT_ROOT);
 
         // Affix trailing slash
         if (DOCUMENT_ROOT.string().size() > 0 && DOCUMENT_ROOT.string().back() != '/')

--- a/src/conf.hpp
+++ b/src/conf.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include "util/string_tools.hpp"
+#include "util/file_tools.hpp"
 #include "util/conf_match.hpp"
 
 #include "../lib/pugixml.hpp"

--- a/src/conf.hpp
+++ b/src/conf.hpp
@@ -30,6 +30,8 @@ namespace conf {
 
     extern std::filesystem::path DOCUMENT_ROOT;
     extern port_t PORT;
+    extern bool IS_IPV4_ENABLED;
+    extern bool IS_IPV6_ENABLED;
     extern unsigned short MAX_REQUEST_BACKLOG;
     extern unsigned int MAX_REQUEST_BUFFER;
     extern std::vector<conf::Match*> matchConfigs;

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -127,6 +127,26 @@ namespace HTTP {
                 // Lookup file
                 File file(pathStr);
 
+                // Handle directory listing
+                if (file.isDirectory) {
+                    bool isDirectoryIndexDisabled = false;
+                    for (conf::Match* pMatch : conf::matchConfigs) {
+                        if (!pMatch->showDirectoryIndexes() && std::regex_match(file.path, pMatch->getPattern())) {
+                            // Hide the directory index
+                            response.setStatus(403);
+                            if (this->isMIMEAccepted("text/html")) // If the request allows HTML, return an HTML display
+                                response.loadBodyFromErrorDoc(403);
+
+                            // Indicate to break outer switch statement
+                            isDirectoryIndexDisabled = true;
+                            break;
+                        }
+                    }
+
+                    // Break if status was set
+                    if (isDirectoryIndexDisabled) break;
+                }
+
                 if (!file.exists) {
                     response.setStatus(404);
                     if (this->isMIMEAccepted("text/html")) // If the request allows HTML, return an HTML display

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -127,6 +127,24 @@ namespace HTTP {
                 // Lookup file
                 File file(pathStr);
 
+                // Catch early caught IO failure
+                if (file.ioFailure) {
+                    // Internal server error from IO
+                    response.setStatus(500);
+                    if (this->isMIMEAccepted("text/html"))
+                        response.loadBodyFromErrorDoc(500);
+                    break;
+                }
+
+                // Verify not a symlink or hardlink
+                if (file.isLinked) {
+                    // If the request allows HTML, return an HTML display
+                    response.setStatus(403);
+                    if (this->isMIMEAccepted("text/html"))
+                        response.loadBodyFromErrorDoc(403);
+                    break;
+                }
+
                 // Handle directory listing
                 if (file.isDirectory) {
                     bool isDirectoryIndexDisabled = false;

--- a/src/http/server-ipv6.hpp
+++ b/src/http/server-ipv6.hpp
@@ -7,8 +7,8 @@ namespace HTTP {
 
     class ServerV6 : public Server {
         public:
-            ServerV6(const port_t port, const u_short maxBacklog, const u_int maxBufferSize, const bool useTLS)
-                : Server(port, maxBacklog, maxBufferSize, useTLS) {};
+            ServerV6(const port_t port, const bool useTLS)
+                : Server(port, useTLS) {};
 
             // Overridden by IPv6 servers
             int bindSocket();

--- a/src/http/server.hpp
+++ b/src/http/server.hpp
@@ -54,8 +54,9 @@ namespace HTTP {
 
     class Server {
         public:
-            Server(const port_t port, const u_short maxBacklog, const u_int maxBufferSize, const bool useTLS)
-                : port(port), maxBacklog(maxBacklog), maxBufferSize(maxBufferSize), useTLS(useTLS) {};
+            Server(const port_t port, const bool useTLS) :
+                port(port), maxBacklog(conf::MAX_REQUEST_BACKLOG), maxBufferSize(conf::MAX_REQUEST_BUFFER),
+                useTLS(useTLS) {};
             virtual ~Server() { this->kill(); };
 
             // Overridden by IPv6 servers

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,14 +89,27 @@ int main() {
     }
 
     // Init server
-    int totalSockets = 2;
-    pServer = new HTTP::Server(conf::PORT, conf::MAX_REQUEST_BACKLOG, conf::MAX_REQUEST_BUFFER, false);
-    pServerV6 = new HTTP::ServerV6(conf::PORT, conf::MAX_REQUEST_BACKLOG, conf::MAX_REQUEST_BUFFER, false);
+    int totalSockets = 0;
+    if (conf::IS_IPV4_ENABLED) {
+        ++totalSockets;
+        pServer = new HTTP::Server(conf::PORT, false);
+    }
+
+    if (conf::IS_IPV6_ENABLED) {
+        ++totalSockets;
+        pServerV6 = new HTTP::ServerV6(conf::PORT, false);
+    }
 
     if (conf::USE_TLS) {
-        totalSockets += 2;
-        pTLSServer = new HTTP::Server(conf::TLS_PORT, conf::MAX_REQUEST_BACKLOG, conf::MAX_REQUEST_BUFFER, true);
-        pTLSServerV6 = new HTTP::ServerV6(conf::TLS_PORT, conf::MAX_REQUEST_BACKLOG, conf::MAX_REQUEST_BUFFER, true);
+        if (conf::IS_IPV4_ENABLED) {
+            ++totalSockets;
+            pTLSServer = new HTTP::Server(conf::TLS_PORT, true);
+        }
+
+        if (conf::IS_IPV6_ENABLED) {
+            ++totalSockets;
+            pTLSServerV6 = new HTTP::ServerV6(conf::TLS_PORT, true);
+        }
     }
 
     // Print welcome banner

--- a/src/util/conf_match.cpp
+++ b/src/util/conf_match.cpp
@@ -19,7 +19,8 @@ namespace conf {
             return nullptr;
         }
 
-        // Extract all Headers
+        /***************************** Extract all Headers *****************************/
+
         pugi::xml_object_range headerNodes = root.children("Header");
 
         for (pugi::xml_node& headerNode : headerNodes) {
@@ -38,6 +39,27 @@ namespace conf {
             // Append header
             pMatch->addHeader(name, value);
         }
+
+        /***************************** Extract ShowDirectoryIndexes *****************************/
+        pugi::xml_node showDirectoryIndexNode = root.child("ShowDirectoryIndexes");
+
+        if (!showDirectoryIndexNode) {
+            std::cerr << "Failed to parse config file, missing ShowDirectoryIndexes node in Match.\n";
+            delete pMatch;
+            return nullptr;
+        }
+
+        std::string showDirectoryIndexStr = showDirectoryIndexNode.text().as_string();
+        trimString(showDirectoryIndexStr);
+
+        // Verify valid value provided
+        if (showDirectoryIndexStr != "on" && showDirectoryIndexStr != "off") {
+            std::cerr << "Failed to parse config file, invalid value for ShowDirectoryIndexes node in Match.\n";
+            delete pMatch;
+            return nullptr;
+        }
+
+        pMatch->setShowDirectoryIndexes( showDirectoryIndexStr == "on" );
 
         // Return Match ptr
         return pMatch;

--- a/src/util/conf_match.hpp
+++ b/src/util/conf_match.hpp
@@ -20,9 +20,12 @@ namespace conf {
             const std::unordered_map<std::string, std::string>& getHeaders() const { return headers; };
 
             const std::regex& getPattern() const { return pattern; };
+            bool showDirectoryIndexes() const { return _showDirectoryIndexes; };
+            void setShowDirectoryIndexes(const bool b) { _showDirectoryIndexes = b; };
         private:
             std::regex pattern;
             std::unordered_map<std::string, std::string> headers;
+            bool _showDirectoryIndexes;
     };
 
     Match* loadMatch(pugi::xml_node&);

--- a/src/util/file.hpp
+++ b/src/util/file.hpp
@@ -14,7 +14,9 @@ class File {
         int loadToBuffer(std::string&);
         std::string getLastModifiedGMT() const;
         bool exists = false;
+        bool isLinked = false; // True if symlink or hardlink
         bool isDirectory = false;
+        bool ioFailure = false; // True if an IO failure occured
 
         std::string MIME;
         std::string path;

--- a/src/util/file_tools.cpp
+++ b/src/util/file_tools.cpp
@@ -1,0 +1,52 @@
+#include "file_tools.hpp"
+
+std::filesystem::path resolveCanonicalPath(const std::filesystem::path& path) {
+    // Note: ChatGPT helped me a bit with this part because WinAPI sucks :p
+    // and I'm doing this to learn socket programming, NOT the Windows API
+
+    #ifdef _WIN32
+        // Check if file exists
+        if (!std::filesystem::exists(path))
+            throw std::filesystem::filesystem_error("File does not exist", path, std::error_code());
+
+        // Get fully-qualified path
+        std::wstring pathStr = path.wstring();
+        wchar_t fullPathStr[MAX_PATH];
+        DWORD result = GetFullPathNameW(pathStr.c_str(), MAX_PATH, fullPathStr, nullptr);
+        if (result == 0 || result >= MAX_PATH)
+            throw std::runtime_error("Failed to get full path name");
+
+        // Open the file to get a handle
+        HANDLE handle = CreateFileW(
+            fullPathStr,
+            0, // No access needed
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS, // To open directories
+            nullptr
+        );
+
+        if (handle == INVALID_HANDLE_VALUE)
+            throw std::runtime_error("Failed to open file handle");
+
+        // Get final path name from file handle
+        wchar_t finalPathStr[MAX_PATH];
+        result = GetFinalPathNameByHandleW(handle, finalPathStr, MAX_PATH, FILE_NAME_NORMALIZED);
+        CloseHandle(handle);
+
+        if (result == 0 || result >= MAX_PATH)
+            throw std::runtime_error("Failed to get final path name");
+
+        // Remove \\?\ prefix if present
+        std::wstring resolvedPathStr(finalPathStr);
+        const std::wstring prefix = L"\\\\?\\";
+        if (resolvedPathStr.compare(0, prefix.length(), prefix) == 0)
+            resolvedPathStr = resolvedPathStr.substr(prefix.length());
+
+        return std::filesystem::path(resolvedPathStr);
+    #else
+        // Linux passthru
+        return std::filesystem::canonical(path);
+    #endif
+}

--- a/src/util/file_tools.hpp
+++ b/src/util/file_tools.hpp
@@ -5,6 +5,12 @@
 #include <string>
 
 #ifdef _WIN32
+    // Fix issue w/ missing headers (before windows.h)
+    #ifdef _WIN32_WINNT
+        #undef _WIN32_WINNT
+    #endif
+    #define _WIN32_WINNT 0x0600
+
     #include <windows.h>
 #endif
 

--- a/src/util/file_tools.hpp
+++ b/src/util/file_tools.hpp
@@ -1,0 +1,13 @@
+#ifndef __FILE_TOOLS_HPP
+#define __FILE_TOOLS_HPP
+
+#include <filesystem>
+#include <string>
+
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
+std::filesystem::path resolveCanonicalPath(const std::filesystem::path& path);
+
+#endif

--- a/src/util/toolbox.hpp
+++ b/src/util/toolbox.hpp
@@ -7,11 +7,22 @@
 #include <string>
 #include <unordered_map>
 
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
 #include "string_tools.hpp"
+#include "file_tools.hpp"
 #include "../conf.hpp"
+
+#define NOT_SYMLINK 0
+#define IS_SYMLINK 1
+#define FILE_NOT_EXIST 2
+#define INTERNAL_ERROR 3
 
 bool doesFileExist(const std::string&, const bool);
 bool doesDirectoryExist(const std::string&, const bool);
+int isSymlinked(const std::filesystem::path&);
 int loadErrorDoc(const int, std::string&);
 
 void formatFileSize(size_t, std::string&);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.7.5
+Mercury v0.7.6


### PR DESCRIPTION
## About
I've added support for toggling IPv4 and IPv6, as well as toggleable directory indexes in Match nodes. Additionally, I've added explicit support for hardlinks and now explicitly block symlink access cross-platform.

This PR closes #20.