### PR TITLE
[Feature] Incorporate Windows Test Runner to Workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,63 @@
+name: Build (Windows)
+
+on:
+    workflow_dispatch:
+    push:
+        branches: ["main"]
+        paths:
+            - "src/**"
+            - "lib/**"
+    pull_request:
+        branches: ["main"]
+        paths:
+            - "src/**"
+            - "lib/**"
+
+jobs:
+    Build:
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            # # Fix executables
+            # - name: Make executable shell scripts
+            #   run: sudo chmod +x ./build_tools/*.sh
+
+            # # Build libraries
+            # - name: Make Libraries
+            #   run: make libs
+
+            # # Build binary
+            # - name: Build Mercury Binary
+            #   run: sudo make linux -B
+
+            # Make log files
+            - name: Make Log Files
+              run: mkdir logs
+
+            # Start Mercury
+            - name: Start Mercury
+              run: |
+                cd bin
+                powershell -command 'Start-Process .\mercury.exe -NoNewWindow -PassThru | ForEach-Object { $_.Id } > ..\pid.txt'
+
+            # Run Python test cases
+            - name: Python Test Runner
+              run: |
+                python --version || choco install python
+                cd tests
+                $output = python run.py
+                echo $output
+                if ($output.Split("`n")[-1] -like "*❌*") {
+                  $pid = Get-Content ..\pid.txt
+                  Stop-Process -Id $pid -Force
+                  Start-Sleep -Seconds 5
+                  exit 1
+                }
+
+            # Kill the server
+            - name: Kill Server
+              run: |
+                $pid = Get-Content pid.txt
+                Stop-Process -Id $pid -Force
+                Start-Sleep -Seconds 5


### PR DESCRIPTION
About
This PR should merge the existing test runner for Windows into a workflow that can be tested to ensure that all test cases pass. While this may likely fail, I have no way to test this until it is merged into main (unless I fork the entire repo myself just to test it).