### PR TITLE
[Bug] Hidden Linux Build Warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 GPP_FLAGS = -Wall -Wextra
 
 STATIC_LIBS_DIR = static_libs
@@ -24,7 +26,8 @@ $(TARGET): $(DEPS)
 		-I$(OPENSSL_DIR)/linux/include -I$(BROTLI_DIR)/linux/include \
 		-L$(OPENSSL_DIR)/linux/lib64 -L$(BROTLI_DIR)/linux/lib \
 		-lssl -lcrypto \
-		$(BROTLI_FLAGS)
+		$(BROTLI_FLAGS) \
+		2> >(grep -v -E "BIO_lookup_ex|getaddrinfo|gethostbyname")
 	@upx $(TARGET) -qqq
 	@echo "✅ Done."
 


### PR DESCRIPTION
## About
As mentioned in issue #38, the build process for Linux has shown a warning for some time now while statically linking all libraries.

```
/usr/bin/ld: static_libs/openssl/linux/lib64/libcrypto.a(libcrypto-lib-bio_addr.o): in function `BIO_lookup_ex':
bio_addr.c:(.text+0xc9e): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: static_libs/openssl/linux/lib64/libcrypto.a(libcrypto-lib-bio_sock.o): in function `BIO_gethostbyname':
bio_sock.c:(.text+0x75): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

Since these warnings refer to methods unused by this project (and likely will continue to be unused), these linker warnings are not a pertinent issue and thus I have filtered them from the console when building.