### PR TITLE
[Bug] Fix Makefile TLS Cert Not Making SSL Directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ release:
 
 # Create a 365-day self-signed TLS 1.3 cert
 cert:
+	@mkdir -p conf/ssl
 	@openssl req -x509 \
 		-newkey rsa:4096 \
 		-keyout conf/ssl/key.pem \


### PR DESCRIPTION
## About
The Makefile "cert" target did not previously create an "ssl" directory if it was missing, causing it to fail. This PR fixes the issue.