### PR TITLE
[Bug] Release Builder Now Creates Releases Directory If Missing

### DIFF
--- a/build_tools/build_release.sh
+++ b/build_tools/build_release.sh
@@ -12,7 +12,10 @@ if [ -d "temp_release" ]; then
 fi
 
 # Clear releases directory
-rm -rf ./releases/*
+if [ -d "releases" ]; then
+    rm -rf releases
+fi
+mkdir releases
 
 # Read version
 VERSION=$(cat version.txt)


### PR DESCRIPTION
## About
Previously, the release builder script would fail if the releases directory was missing. However since #63 and #64, the releases directory has been removed from the committed repository structure and thus this issue has become more prevalent.

This small addition to the script wipes the releases directory if it exists and then remakes it fresh so that the new release can be built properly.