### PR TITLE
[Misc.] Integrate Fresh Build Into Test Runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,15 @@ on:
 
 jobs:
     Build:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
 
             - name: Cache APT packages
               uses: actions/cache@v4
               with:
-                path: |
-                    /var/cache/apt/archives
-                    /var/lib/apt/lists
-                key: ${{ runner.os }}-apt-${{ hashFiles('**/build_tools/install_deps.sh') }}
+                path: ./static_libs
+                key: ${{ runner.os }}-libs-linux-${{ hashFiles('**/build_tools/install_deps.sh') }}
 
             # Make executables
             - name: Make Executable Shell Ccripts
@@ -33,7 +31,10 @@ jobs:
 
             # Install deps & build static binaries
             - name: Install Deps & Build Libs
-              run: make libs
+              run: |
+                if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
+                  make libs
+                fi
 
             # Build
             - name: Build Mercury Binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Install Deps & Build Libs
               run: |
                 # Run w/o make (not installed yet)
-                sudo ./build_tools/install_deps.sh
+                sudo apt-get install make
                 if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
                   make libs
                 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,16 @@ on:
 
 jobs:
     Build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v4
 
-            - name: Cache APT packages
+            # Mark artifacts for caching
+            - name: Cache Library Artifacts
               uses: actions/cache@v4
               with:
                 path: ./static_libs
-                key: ${{ runner.os }}-libs-linux-${{ hashFiles('**/build_tools/install_deps.sh') }}
+                key: ${{ runner.os }}-artifacts-${{ hashFiles('**/build_tools/install_deps.sh') }}
 
             # Make executables
             - name: Make Executable Shell Ccripts
@@ -32,6 +33,8 @@ jobs:
             # Install deps & build static binaries
             - name: Install Deps & Build Libs
               run: |
+                # Run w/o make (not installed yet)
+                sudo ./build_tools/install_deps.sh
                 if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
                   make libs
                 fi
@@ -39,3 +42,12 @@ jobs:
             # Build
             - name: Build Mercury Binaries
               run: sudo make -B
+
+            # Upload build artifacts
+            - name: Upload Build Artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: mercury-binaries
+                path: ./bin
+
+            # TODO - start Linux & Windows workflows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
                   make libs
                 fi
 
+                # Build static zlib anyways (can't cache, takes < 10 sec)
+                make static_zlib
+
             # Build
             - name: Build Mercury Binaries
               run: sudo make -B

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
             # Upload build artifacts
             - name: Upload Build Artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: mercury-binaries
                 path: ./bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: ./static_libs
-                key: ${{ runner.os }}-artifacts-${{ hashFiles('**/build_tools/**') }}
+                key: ${{ runner.os }}-artifacts-${{ hashFiles('**/build_tools/build_static_brotli.sh', '**/build_tools/build_static_openssl.sh') }}
 
             # Make executables
             - name: Make Executable Shell Ccripts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,15 @@ jobs:
               with:
                 name: mercury-binaries
                 path: ./bin
+
+    Run-Linux-Tests:
+      needs: Build
+      uses: ./.github/workflows/test-linux.yml
+      with:
+        artifact-name: mercury-binaries
+
+    Run-Windows-Tests:
+      needs: Build
+      uses: ./.github/workflows/test-windows.yml
+      with:
+        artifact-name: mercury-binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Test
 
 on:
     workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,10 @@ jobs:
             - name: Install Deps & Build Libs
               run: |
                 # Run w/o make (not installed yet)
-                sudo apt-get install make
+                sudo ./build_tools/install_deps.sh
                 if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
-                  make libs
+                  make static_brotli
+                  make static_openssl
                 fi
 
                 # Build static zlib anyways (can't cache, takes < 10 sec)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: ./static_libs
-                key: ${{ runner.os }}-artifacts-${{ hashFiles('**/build_tools/install_deps.sh') }}
+                key: ${{ runner.os }}-artifacts-${{ hashFiles('**/build_tools/**') }}
 
             # Make executables
             - name: Make Executable Shell Ccripts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,3 @@ jobs:
               with:
                 name: mercury-binaries
                 path: ./bin
-
-            # TODO - start Linux & Windows workflows

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -86,7 +86,6 @@ jobs:
             # Run Python test cases
             - name: Python Test Runner
               run: |
-                sudo apt install python3
                 cd tests
                 OUTPUT=$(python3 run.py)
                 echo "$OUTPUT"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,9 +15,32 @@ on:
 
 jobs:
     Build:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+
+            # Mark artifacts for caching
+            - name: Cache Library Artifacts
+              uses: actions/cache@v4
+              with:
+                path: ./static_libs
+                key: ${{ runner.os }}-artifacts-linux-${{ hashFiles('**/build_tools/install_deps.sh') }}
+
+            # Make executables
+            - name: Make Executable Shell Ccripts
+              run: sudo chmod +x ./build_tools/*.sh
+
+            # Install deps & build static binaries
+            - name: Install Deps & Build Libs
+              run: |
+                make static_deps
+                if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
+                  make runners_libs_linux
+                fi
+
+            # Build
+            - name: Build Mercury Binaries
+              run: sudo make linux -B
 
             - name: Configure Ports & Enable IPv4 & IPv6
               run: |
@@ -57,7 +80,7 @@ jobs:
             - name: Start Mercury
               run: |
                 cd bin
-                chmod +x ./mercury
+                sudo chmod +x ./mercury
                 sudo ./mercury & echo $! > ../pid.txt
 
             # Run Python test cases

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
     Build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v4
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -33,7 +33,8 @@ jobs:
             # Install deps & build static binaries
             - name: Install Deps & Build Libs
               run: |
-                make static_deps
+                # Run w/o make (not installed yet)
+                sudo ./build_tools/install_deps.sh
                 if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
                   make runners_libs_linux
                 fi

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v4
 
             # Download binaries
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                 name: mercury-binaries
                 path: ./bin

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,11 +1,11 @@
 name: Test Runner (Linux)
 
 on:
-  workflow_dispatch:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
 
 jobs:
     Build:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,6 +1,7 @@
 name: Test Runner (Linux)
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Build"]
     types:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-    Build:
+    Test-Linux:
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,17 +1,10 @@
 name: Test Runner (Linux)
 
 on:
-    workflow_dispatch:
-    push:
-        branches: ["main"]
-        paths:
-            - "src/**"
-            - "lib/**"
-    pull_request:
-        branches: ["main"]
-        paths:
-            - "src/**"
-            - "lib/**"
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
     Build:
@@ -19,29 +12,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            # Mark artifacts for caching
-            - name: Cache Library Artifacts
-              uses: actions/cache@v4
+            # Download binaries
+            - uses: actions/download-artifact@v3
               with:
-                path: ./static_libs
-                key: ${{ runner.os }}-artifacts-linux-${{ hashFiles('**/build_tools/install_deps.sh') }}
-
-            # Make executables
-            - name: Make Executable Shell Ccripts
-              run: sudo chmod +x ./build_tools/*.sh
-
-            # Install deps & build static binaries
-            - name: Install Deps & Build Libs
-              run: |
-                # Run w/o make (not installed yet)
-                sudo ./build_tools/install_deps.sh
-                if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
-                  make runners_libs_linux
-                fi
-
-            # Build
-            - name: Build Mercury Binaries
-              run: sudo make linux -B
+                name: mercury-binaries
+                path: ./bin
 
             - name: Configure Ports & Enable IPv4 & IPv6
               run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -19,6 +19,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: Vampire/setup-wsl@v6
+              with:
+                distribution: Ubuntu-24.04
 
             # Mark artifacts for caching
             - name: Cache Library Artifacts

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-    Build:
+    Test-Windows:
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -21,6 +21,7 @@ jobs:
             - uses: Vampire/setup-wsl@v6
               with:
                 distribution: Ubuntu-24.04
+                use-cache: 'true'
 
             # Mark artifacts for caching
             - name: Cache Library Artifacts

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,7 +36,8 @@ jobs:
             - name: Install Deps & Build Libs
               shell: wsl-bash {0}
               run: |
-                make static_deps
+                # Run w/o make (not installed yet)
+                sudo ./build_tools/install_deps.sh
                 if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
                   make runners_libs_win
                 fi

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,54 +1,22 @@
 name: Test Runner (Windows)
 
 on:
-    workflow_dispatch:
-    push:
-        branches: ["main"]
-        paths:
-            - "src/**"
-            - "lib/**"
-    pull_request:
-        branches: ["main"]
-        paths:
-            - "src/**"
-            - "lib/**"
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
     Build:
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: Vampire/setup-wsl@v6
+
+            # Download binaries
+            - uses: actions/download-artifact@v3
               with:
-                distribution: Ubuntu-24.04
-                use-cache: 'true'
-
-            # Mark artifacts for caching
-            - name: Cache Library Artifacts
-              uses: actions/cache@v4
-              with:
-                path: ./static_libs
-                key: ${{ runner.os }}-artifacts-windows-${{ hashFiles('**/build_tools/install_deps.sh') }}
-
-            # Make executables
-            - name: Make Executable Shell Ccripts
-              shell: wsl-bash {0}
-              run: sudo chmod +x ./build_tools/*.sh
-
-            # Install deps & build static binaries
-            - name: Install Deps & Build Libs
-              shell: wsl-bash {0}
-              run: |
-                # Run w/o make (not installed yet)
-                sudo ./build_tools/install_deps.sh
-                if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
-                  make runners_libs_win
-                fi
-
-            # Build
-            - name: Build Mercury Binaries
-              shell: wsl-bash {0}
-              run: sudo make windows -B
+                name: mercury-binaries
+                path: ./bin
 
             - name: Configure Ports & Enable IPv4 & IPv6
               run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,11 +1,11 @@
 name: Test Runner (Windows)
 
 on:
-  workflow_dispatch:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
 
 jobs:
     Build:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v4
 
             # Download binaries
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                 name: mercury-binaries
                 path: ./bin

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,7 @@
 name: Test Runner (Windows)
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Build"]
     types:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -18,6 +18,33 @@ jobs:
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v4
+            - uses: Vampire/setup-wsl@v6
+
+            # Mark artifacts for caching
+            - name: Cache Library Artifacts
+              uses: actions/cache@v4
+              with:
+                path: ./static_libs
+                key: ${{ runner.os }}-artifacts-windows-${{ hashFiles('**/build_tools/install_deps.sh') }}
+
+            # Make executables
+            - name: Make Executable Shell Ccripts
+              shell: wsl-bash {0}
+              run: sudo chmod +x ./build_tools/*.sh
+
+            # Install deps & build static binaries
+            - name: Install Deps & Build Libs
+              shell: wsl-bash {0}
+              run: |
+                make static_deps
+                if [ ! -d static_libs ] || [ -z "$(ls -A static_libs)" ]; then
+                  make runners_libs_win
+                fi
+
+            # Build
+            - name: Build Mercury Binaries
+              shell: wsl-bash {0}
+              run: sudo make windows -B
 
             - name: Configure Ports & Enable IPv4 & IPv6
               run: |

--- a/Makefile
+++ b/Makefile
@@ -98,19 +98,6 @@ static_zlib:
 release:
 	@./build_tools/build_release.sh
 
-#### TARGETS ONLY FOR GITHUB ACTIONS RUNNERS
-
-runners_libs_win:
-	@./build_tools/install_deps.sh
-	@./build_tools/build_static_brotli.sh "windows"
-	@./build_tools/build_static_openssl.sh "windows"
-	@./build_tools/build_static_zlib.sh
-
-runners_libs_linux:
-	@./build_tools/install_deps.sh
-	@./build_tools/build_static_brotli.sh "linux"
-	@./build_tools/build_static_openssl.sh "linux"
-
 ############################ TLS CERTS ############################
 
 # Create a 365-day self-signed TLS 1.3 cert

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,19 @@ static_zlib:
 release:
 	@./build_tools/build_release.sh
 
+#### TARGETS ONLY FOR GITHUB ACTIONS RUNNERS
+
+runners_libs_win:
+	@./build_tools/install_deps.sh
+	@./build_tools/build_static_brotli.sh "windows"
+	@./build_tools/build_static_openssl.sh "windows"
+	@./build_tools/build_static_zlib.sh
+
+runners_libs_linux:
+	@./build_tools/install_deps.sh
+	@./build_tools/build_static_brotli.sh "linux"
+	@./build_tools/build_static_openssl.sh "linux"
+
 ############################ TLS CERTS ############################
 
 # Create a 365-day self-signed TLS 1.3 cert

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ### A project by Travis Heavener
 
 [![Build](https://github.com/travis-heavener/mercury/actions/workflows/build.yml/badge.svg)](https://github.com/travis-heavener/mercury/actions/workflows/build.yml)
-[![Test Runner (Linux)](https://github.com/travis-heavener/mercury/actions/workflows/test-linux.yml/badge.svg)](https://github.com/travis-heavener/mercury/actions/workflows/test-linux.yml)
-[![Test Runner (Windows)](https://github.com/travis-heavener/mercury/actions/workflows/test-windows.yml/badge.svg)](https://github.com/travis-heavener/mercury/actions/workflows/test-windows.yml)
 
 ## Table of Contents
 

--- a/build_tools/build_static_brotli.sh
+++ b/build_tools/build_static_brotli.sh
@@ -22,49 +22,54 @@ fi
 # Clone Brotli repo
 git clone https://github.com/google/brotli ./brotli-repo
 cd brotli-repo
+mkdir -p $LIB_PATH/brotli
 mkdir build && cd build
 
 # ==== Linux Build ====
 
-# Prepare CMAKE for compilation
-cmake .. \
+if [ -z "$1" ] || [ "$1" == "linux" ]; then
+    # Prepare CMAKE for compilation
+    cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DBROTLI_BUNDLED_MODE=ON \
     -DBUILD_SHARED_LIBS=OFF
 
-# Build
-make
+    # Build
+    make
 
-# Extract resources
-mkdir $LIB_PATH/brotli $LIB_PATH/brotli/linux $LIB_PATH/brotli/linux/lib
+    # Extract resources
+    mkdir $LIB_PATH/brotli/linux $LIB_PATH/brotli/linux/lib
 
-mv *.a $LIB_PATH/brotli/linux/lib
-cp -r $LIB_PATH/brotli-repo/c/include $LIB_PATH/brotli/linux/include
+    mv *.a $LIB_PATH/brotli/linux/lib
+    cp -r $LIB_PATH/brotli-repo/c/include $LIB_PATH/brotli/linux/include
+fi
 
+cd ..
 # ==== Windows Build ====
 
 # Wipe build dir
-cd ..
-rm -rf build
-mkdir build && cd build
+if [ -z "$1" ] || [ "$1" == "windows" ]; then
+    rm -rf build
+    mkdir build && cd build
 
-# Set Windows cross-compiling with MinGW
-cmake .. \
-    -DCMAKE_SYSTEM_NAME=Windows \
-    -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
-    -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBROTLI_BUNDLED_MODE=ON \
-    -DBUILD_SHARED_LIBS=OFF
+    # Set Windows cross-compiling with MinGW
+    cmake .. \
+        -DCMAKE_SYSTEM_NAME=Windows \
+        -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
+        -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBROTLI_BUNDLED_MODE=ON \
+        -DBUILD_SHARED_LIBS=OFF
 
-# Build
-make
+    # Build
+    make
 
-# Extract headers & linker files
-mkdir $LIB_PATH/brotli/windows $LIB_PATH/brotli/windows/lib
+    # Extract headers & linker files
+    mkdir $LIB_PATH/brotli/windows $LIB_PATH/brotli/windows/lib
 
-mv *.a $LIB_PATH/brotli/windows/lib
-mv $LIB_PATH/brotli-repo/c/include $LIB_PATH/brotli/windows/include
+    mv *.a $LIB_PATH/brotli/windows/lib
+    mv $LIB_PATH/brotli-repo/c/include $LIB_PATH/brotli/windows/include
+fi
 
 # ==== Clean Up ====
 cd $LIB_PATH

--- a/build_tools/build_static_openssl.sh
+++ b/build_tools/build_static_openssl.sh
@@ -15,59 +15,61 @@ if [ -d "openssl-3.5.0" ]; then
     rm -rf openssl-3.5.0
 fi
 
-if [ -d "openssl" ]; then
-    rm -rf openssl
-fi
-
 if [ -f "openssl-3.5.0.tar.gz" ]; then
     rm -f openssl-3.5.0.tar.gz
 fi
 
+# Get OpenSSL source
+wget -q --no-check-certificate https://www.openssl.org/source/openssl-3.5.0.tar.gz
+echo "Fetched OpenSSL archive."
+
 # ==== Linux Build ====
 
-# Get OpenSSL source
-wget -q https://www.openssl.org/source/openssl-3.5.0.tar.gz
+if [ -z "$1" ] || [ "$1" == "linux" ]; then
+    # Unpack tar
+    tar -xzf openssl-3.5.0.tar.gz
+    echo "Extracted archive."
+    cd openssl-3.5.0
 
-echo "Fetched OpenSSL archive."
-tar -xzf openssl-3.5.0.tar.gz
-echo "Extracted archive."
+    # Configure static build
+    echo "Configuring build... This may take a minute."
+    ./Configure linux-x86_64 no-shared no-dso no-ssl3 no-comp --prefix=$LIB_PATH/openssl/linux 1> /dev/null
 
-cd openssl-3.5.0
+    # Build static
+    make -j$(nproc) 1> /dev/null
 
-# Configure static build
-echo "Configuring build... This may take a minute."
-./Configure linux-x86_64 no-shared no-dso no-ssl3 no-comp --prefix=$LIB_PATH/openssl/linux 1> /dev/null
+    # Install binaries
+    make install_sw 1> /dev/null
+    echo "Built Linux binaries."
 
-# Build static
-make -j$(nproc) 1> /dev/null
-
-# Install binaries
-make install_sw 1> /dev/null
-echo "Built Linux binaries."
-
-# Reset for Windows build
-cd ..
-rm -rf openssl-3.5.0
+    # Reset for Windows build
+    cd ..
+    rm -rf openssl-3.5.0
+fi
 
 # ==== Windows Build ====
 
-# Unpack tar
-tar -xzf openssl-3.5.0.tar.gz
-echo "Extracted archive."
-cd openssl-3.5.0
+if [ -z "$1" ] || [ "$1" == "windows" ]; then
+    # Unpack tar
+    tar -xzf openssl-3.5.0.tar.gz
+    echo "Extracted archive."
+    cd openssl-3.5.0
 
-# Reconfigure for Windows build
-echo "Configuring build... This may take a minute."
-./Configure mingw64 no-shared no-dso no-asm no-ssl3 no-comp --cross-compile-prefix=x86_64-w64-mingw32- enable-ec_nistp_64_gcc_128 --prefix=$LIB_PATH/openssl/windows 1> /dev/null
+    # Reconfigure for Windows build
+    echo "Configuring build... This may take a minute."
+    ./Configure mingw64 no-shared no-dso no-asm no-ssl3 no-comp --cross-compile-prefix=x86_64-w64-mingw32- enable-ec_nistp_64_gcc_128 --prefix=$LIB_PATH/openssl/windows 1> /dev/null
 
-# Build OpenSSL static for Windows
-make -j$(nproc) 1> /dev/null
-make install_sw 1> /dev/null
-echo "Built Windows binaries."
+    # Build OpenSSL static for Windows
+    make -j$(nproc) 1> /dev/null
+    make install_sw 1> /dev/null
+    echo "Built Windows binaries."
+
+    cd ..
+    rm -rf openssl-3.5.0
+fi
 
 # ==== Clean Up ====
 
-rm -rf $LIB_PATH/openssl-3.5.0
 rm -f $LIB_PATH/openssl-3.5.0.tar.gz
 
 echo "✅ Successfully built static OpenSSL binaries."

--- a/build_tools/install_deps.sh
+++ b/build_tools/install_deps.sh
@@ -8,6 +8,7 @@ sudo apt install upx \
     cmake \
     zlib1g-dev \
     g++ \
-    zip -y
+    zip \
+    python3 -y
 
 echo "✅ Successfully installed dependencies."

--- a/build_tools/install_deps.sh
+++ b/build_tools/install_deps.sh
@@ -8,7 +8,6 @@ sudo apt install upx \
     cmake \
     zlib1g-dev \
     g++ \
-    zip \
-    mingw-w64 -y
+    zip -y
 
 echo "✅ Successfully installed dependencies."

--- a/build_tools/install_deps.sh
+++ b/build_tools/install_deps.sh
@@ -5,7 +5,7 @@ sudo apt update
 sudo apt install upx \
     build-essential perl wget \
     mingw-w64 nasm \
-    cmake \
+    cmake make \
     zlib1g-dev \
     g++ \
     zip \


### PR DESCRIPTION
## About
Per #66, I've integrated the build functionality (GNU Make) into the test runners' workflows. The original Build workflow (now Build & Test) builds library artifacts and caches them (Brotli & OpenSSL), then builds the Mercury binaries and uploads them so that it can call the test runners and download those binaries for testing.

This approach is faster than two separate workflows since it meant that the Windows runner would use WSL to build libraries and Mercury binaries (took 50 minutes compared to 8 minutes).

These changes also dramatically improve testing time. It takes about 2 minutes to test both test runner workflows AND build (assuming the cache hits). The cache is deleted after 7 days of inactivity, which will then mean that it takes about 9 minutes (which is what it previously took to build).

Altogether these changes are a huge win for this project's CI/CD pipeline.