### PR TITLE
[Feature] Test Runner Now Fails on Socket Failure

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
 
     # Run IPv4 test cases
     num_passing = 0
-    num_total = 0
+    num_total = len(cases) * 4
     try:
         for i, test_case in enumerate(cases):
             # Open the socket connection
@@ -37,7 +37,6 @@ if __name__ == "__main__":
                     print(f"Failed IPv4 test #{i+1}")
                 else:
                     num_passing += 1
-        num_total += len(cases)
     except:
         print("[Note]: IPv4 connection failure")
 
@@ -52,7 +51,6 @@ if __name__ == "__main__":
                         print(f"Failed IPv4 SSL test #{i+1}")
                     else:
                         num_passing += 1
-        num_total += len(cases)
     except:
         print("[Note]: IPv4 SSL connection failure")
 
@@ -68,7 +66,6 @@ if __name__ == "__main__":
                     print(f"Failed IPv6 test #{i+1}")
                 else:
                     num_passing += 1
-        num_total += len(cases)
     except:
         print("[Note]: IPv6 connection failure")
 
@@ -83,7 +80,6 @@ if __name__ == "__main__":
                         print(f"Failed IPv6 SSL test #{i+1}")
                     else:
                         num_passing += 1
-        num_total += len(cases)
     except:
         print("[Note]: IPv6 SSL connection failure")
 


### PR DESCRIPTION
## About
The test runner previously would just warn the user if it had failed to connect to a server socket (ie. IPv6 failure with older Windows builds), allowing it to complete with success. This PR makes the test script more strict and will fail if any connection fails, making the GH Actions workflows more effective in spotting connection failure in addition to forcing more thorough local testing.