### PR TITLE
[Bug] Gitignore Artifacts Lock File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ static_libs/*
 *.pem
 releases/*
 bin/*
+artifacts.lock

--- a/artifacts.lock
+++ b/artifacts.lock
@@ -1,3 +1,0 @@
-openssl=3.5.2
-zlib=1.3.1
-brotli=1.1.0


### PR DESCRIPTION
## About
After creating the artifacts.lock file in v0.9.2, I forgot to gitignore it which would essentially defeat the entire purpose of itself. This hotfix PR resolves that issue.