### PR TITLE
[Feature] Improved Artifact Version Validator

### DIFF
--- a/build_tools/validate_libs.sh
+++ b/build_tools/validate_libs.sh
@@ -15,8 +15,7 @@ ZLIB_VERSION="1.3.1"
 
 # Verify artifacts.lock exists
 if [ ! -e "artifacts.lock" ]; then
-    echo "Missing artifacts.lock in project root"
-    exit 1
+    touch artifacts.lock
 fi
 
 # Remove CRLF for LF


### PR DESCRIPTION
## About
The library artifact version validator Bash script now creates an artifacts.lock file if one doesn't exist and will now continue the rest of the script after that point, allowing the developer to see what needs to be updated instead of telling them their artifacts.lock file doesn't exist.