### PR TITLE
[Feature] Refactor Artifacts Lock File

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ static_zlib:
 	@./build_tools/build_static_zlib.sh
 
 release:
+	@./build_tools/validate_libs.sh --q
 	@./build_tools/build_release.sh
 
 ############################ TLS CERTS ############################

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GPP_FLAGS = -Wall -Wextra -Winvalid-pch
 STATIC_LIBS_DIR = static_libs
 OPENSSL_DIR = $(STATIC_LIBS_DIR)/openssl
 BROTLI_DIR = $(STATIC_LIBS_DIR)/brotli
+ARTIFACTS_LOCK = $(STATIC_LIBS_DIR)/artifacts.lock
 PCH_DIR = src/pch
 
 STATIC_FLAGS = -static -static-libgcc -static-libstdc++ -std=c++17
@@ -20,7 +21,7 @@ all: pch_linux $(TARGET) pch_windows $(TARGET_WIN)
 linux: pch_linux $(TARGET)
 windows: pch_windows $(TARGET_WIN)
 
-$(TARGET): $(DEPS)
+$(TARGET): $(DEPS) $(ARTIFACTS_LOCK)
 	@./build_tools/validate_libs.sh --q
 	@echo -n "Building for Linux... "
 	@mkdir -p ./bin
@@ -36,7 +37,7 @@ $(TARGET): $(DEPS)
 	@upx $(TARGET) -qqq
 	@echo "✅ Done."
 
-$(TARGET_WIN): $(DEPS) src/winheader.hpp
+$(TARGET_WIN): $(DEPS) src/winheader.hpp $(ARTIFACTS_LOCK)
 	@./build_tools/validate_libs.sh --q
 	@echo -n "Building for Windows... "
 	@mkdir -p ./bin
@@ -55,11 +56,10 @@ $(TARGET_WIN): $(DEPS) src/winheader.hpp
 
 # Precompiled headers
 pch: pch_linux pch_windows
-
 pch_linux: $(PCH_DIR)/common-linux.hpp.gch
 pch_windows: $(PCH_DIR)/common-win.hpp.gch
 
-$(PCH_DIR)/common-linux.hpp.gch: $(PCH_DIR)/common-linux.hpp $(PCH_DIR)/common.hpp
+$(PCH_DIR)/common-linux.hpp.gch: $(PCH_DIR)/common-linux.hpp $(PCH_DIR)/common.hpp $(ARTIFACTS_LOCK)
 	@./build_tools/validate_libs.sh --q
 	@mkdir -p ./bin
 	@echo -n "Building Linux PCH... "
@@ -73,7 +73,7 @@ $(PCH_DIR)/common-linux.hpp.gch: $(PCH_DIR)/common-linux.hpp $(PCH_DIR)/common.h
 		-o $(PCH_DIR)/common-linux.hpp.gch
 	@echo "✅ Done."
 
-$(PCH_DIR)/common-win.hpp.gch: $(PCH_DIR)/common-win.hpp $(PCH_DIR)/common.hpp
+$(PCH_DIR)/common-win.hpp.gch: $(PCH_DIR)/common-win.hpp $(PCH_DIR)/common.hpp $(ARTIFACTS_LOCK)
 	@./build_tools/validate_libs.sh --q
 	@mkdir -p ./bin
 	@echo -n "Building Windows PCH... "

--- a/build_tools/build_static_brotli.sh
+++ b/build_tools/build_static_brotli.sh
@@ -14,13 +14,21 @@ LIB_PATH=$(pwd)
 version="1.1.0"
 if [ ! -e "artifacts.lock" ]; then
     touch artifacts.lock
+    echo "" | gzip | base64 > artifacts.lock
 fi
 
-if grep -q "^brotli=" artifacts.lock; then
-    sed -i "s/^brotli=.*$/brotli=$version/" artifacts.lock
+# Unpack artifacts
+cat artifacts.lock | base64 --decode | gunzip > artifacts.raw
+
+if grep -q "^brotli=" artifacts.raw; then
+    sed -i "s/^brotli=.*$/brotli=$version/" artifacts.raw
 else
-    { echo "brotli=$version"; cat artifacts.lock; } > temp && mv temp artifacts.lock
+    { echo "brotli=$version"; cat artifacts.raw; } > temp && mv temp artifacts.raw
 fi
+
+# Repack artifacts
+cat artifacts.raw | gzip | base64 > artifacts.lock
+rm -f artifacts.raw
 
 # Clean existing
 if [ -d "brotli" ]; then

--- a/build_tools/build_static_brotli.sh
+++ b/build_tools/build_static_brotli.sh
@@ -3,6 +3,13 @@
 # CD into project directory
 cd "$(dirname "$0")/../"
 
+if [ ! -d "static_libs" ]; then
+    mkdir static_libs
+fi
+
+cd static_libs
+LIB_PATH=$(pwd)
+
 # Update artifacts.lock
 version="1.1.0"
 if [ ! -e "artifacts.lock" ]; then
@@ -14,13 +21,6 @@ if grep -q "^brotli=" artifacts.lock; then
 else
     { echo "brotli=$version"; cat artifacts.lock; } > temp && mv temp artifacts.lock
 fi
-
-if [ ! -d "static_libs" ]; then
-    mkdir static_libs
-fi
-
-cd static_libs
-LIB_PATH=$(pwd)
 
 # Clean existing
 if [ -d "brotli" ]; then

--- a/build_tools/build_static_openssl.sh
+++ b/build_tools/build_static_openssl.sh
@@ -3,6 +3,17 @@
 # CD into project directory
 cd "$(dirname "$0")/../"
 
+if [ -d "openssl" ]; then
+    rm -rf openssl
+fi
+
+if [ ! -d "static_libs" ]; then
+    mkdir static_libs
+fi
+
+cd static_libs
+LIB_PATH=$(pwd)
+
 # Update artifacts.lock
 version="3.5.2"
 if [ ! -e "artifacts.lock" ]; then
@@ -14,17 +25,6 @@ if grep -q "^openssl=" artifacts.lock; then
 else
     { echo "openssl=$version"; cat artifacts.lock; } > temp && mv temp artifacts.lock
 fi
-
-if [ -d "openssl" ]; then
-    rm -rf openssl
-fi
-
-if [ ! -d "static_libs" ]; then
-    mkdir static_libs
-fi
-
-cd static_libs
-LIB_PATH=$(pwd)
 
 # Clean existing
 if [ -d "openssl-$version" ]; then

--- a/build_tools/build_static_openssl.sh
+++ b/build_tools/build_static_openssl.sh
@@ -18,13 +18,21 @@ LIB_PATH=$(pwd)
 version="3.5.2"
 if [ ! -e "artifacts.lock" ]; then
     touch artifacts.lock
+    echo "" | gzip | base64 > artifacts.lock
 fi
 
-if grep -q "^openssl=" artifacts.lock; then
-    sed -i "s/^openssl=.*$/openssl=$version/" artifacts.lock
+# Unpack artifacts
+cat artifacts.lock | base64 --decode | gunzip > artifacts.raw
+
+if grep -q "^openssl=" artifacts.raw; then
+    sed -i "s/^openssl=.*$/openssl=$version/" artifacts.raw
 else
-    { echo "openssl=$version"; cat artifacts.lock; } > temp && mv temp artifacts.lock
+    { echo "openssl=$version"; cat artifacts.raw; } > temp && mv temp artifacts.raw
 fi
+
+# Repack artifacts
+cat artifacts.raw | gzip | base64 > artifacts.lock
+rm -f artifacts.raw
 
 # Clean existing
 if [ -d "openssl-$version" ]; then

--- a/build_tools/build_static_zlib.sh
+++ b/build_tools/build_static_zlib.sh
@@ -14,13 +14,21 @@ LIB_PATH=$(pwd)
 version="1.3.1"
 if [ ! -e "artifacts.lock" ]; then
     touch artifacts.lock
+    echo "" | gzip | base64 > artifacts.lock
 fi
 
-if grep -q "^zlib=" artifacts.lock; then
-    sed -i "s/^zlib=.*$/zlib=$version/" artifacts.lock
+# Unpack artifacts
+cat artifacts.lock | base64 --decode | gunzip > artifacts.raw
+
+if grep -q "^zlib=" artifacts.raw; then
+    sed -i "s/^zlib=.*$/zlib=$version/" artifacts.raw
 else
-    { echo "zlib=$version"; cat artifacts.lock; } > temp && mv temp artifacts.lock
+    { echo "zlib=$version"; cat artifacts.raw; } > temp && mv temp artifacts.raw
 fi
+
+# Repack artifacts
+cat artifacts.raw | gzip | base64 > artifacts.lock
+rm -f artifacts.raw
 
 # ==== Config ====
 ZLIB_DIR="$LIB_PATH/zlib-repo"

--- a/build_tools/build_static_zlib.sh
+++ b/build_tools/build_static_zlib.sh
@@ -3,6 +3,13 @@
 # CD into project directory
 cd "$(dirname "$0")/../"
 
+if [ ! -d "static_libs" ]; then
+    mkdir static_libs
+fi
+
+cd static_libs
+LIB_PATH=$(pwd)
+
 # Update artifacts.lock
 version="1.3.1"
 if [ ! -e "artifacts.lock" ]; then
@@ -14,13 +21,6 @@ if grep -q "^zlib=" artifacts.lock; then
 else
     { echo "zlib=$version"; cat artifacts.lock; } > temp && mv temp artifacts.lock
 fi
-
-if [ ! -d "static_libs" ]; then
-    mkdir static_libs
-fi
-
-cd static_libs
-LIB_PATH=$(pwd)
 
 # ==== Config ====
 ZLIB_DIR="$LIB_PATH/zlib-repo"

--- a/build_tools/install_deps.sh
+++ b/build_tools/install_deps.sh
@@ -9,6 +9,7 @@ sudo apt install upx \
     zlib1g-dev \
     g++ \
     zip \
-    python3 -y
+    python3 \
+    gzip -y
 
 echo "✅ Successfully installed dependencies."

--- a/build_tools/validate_libs.sh
+++ b/build_tools/validate_libs.sh
@@ -9,6 +9,13 @@
 # CD into project directory
 cd "$(dirname "$0")/../"
 
+if [ ! -d "static_libs" ]; then
+    mkdir static_libs
+fi
+
+cd static_libs
+
+# Declare versions
 BROTLI_VERSION="1.1.0"
 OPENSSL_VERSION="3.5.2"
 ZLIB_VERSION="1.3.1"

--- a/build_tools/validate_libs.sh
+++ b/build_tools/validate_libs.sh
@@ -23,33 +23,41 @@ ZLIB_VERSION="1.3.1"
 # Verify artifacts.lock exists
 if [ ! -e "artifacts.lock" ]; then
     touch artifacts.lock
+    echo "" | gzip | base64 > artifacts.lock
 fi
 
+# Unpack artifacts
+cat artifacts.lock | base64 --decode | gunzip > artifacts.raw
+
 # Remove CRLF for LF
-sed -i 's/\r//g' artifacts.lock
+sed -i 's/\r//g' artifacts.raw
 
 # === Brotli ===
 
 HAS_FAILED="false"
 
-if ! grep -q "^brotli=${BROTLI_VERSION}\$" artifacts.lock; then
+if ! grep -q "^brotli=${BROTLI_VERSION}\$" artifacts.raw; then
     echo "Update Brotli to $BROTLI_VERSION via \`make static_brotli\`"
     HAS_FAILED="true"
 fi
 
 # === OpenSSL ===
 
-if ! grep -q "^openssl=${OPENSSL_VERSION}\$" artifacts.lock; then
+if ! grep -q "^openssl=${OPENSSL_VERSION}\$" artifacts.raw; then
     echo "Update OpenSSL to $OPENSSL_VERSION via \`make static_openssl\`"
     HAS_FAILED="true"
 fi
 
 # === zlib ===
 
-if ! grep -q "^zlib=${ZLIB_VERSION}\$" artifacts.lock; then
+if ! grep -q "^zlib=${ZLIB_VERSION}\$" artifacts.raw; then
     echo "Update zlib to $ZLIB_VERSION via \`make static_zlib\`"
     HAS_FAILED="true"
 fi
+
+# === Close up ===
+
+rm -f artifacts.raw
 
 if [ $HAS_FAILED == "true" ]; then
     exit 1


### PR DESCRIPTION
## About
I've enforced library version validation in this update when building releases to prevent building with outdated dependencies. I've also refactored the artifacts.lock file to the static_libs directory in conjunction with the rest of the static library builds.

To help in preventing accidental tampering of the artifacts.lock file (& to prevent bundling with outdated deps), I've obfuscated the data within the file with base64 & gzip.

Lastly, I've updated the Makefile so that Mercury binaries' targets now also take the artifacts.lock file as a dependency, so that the binaries can be rebuilt if the dependencies update.