### PR TITLE
[Misc.] Create Action Workflow to Automate Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build & Test
 
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches: ["main"]
     paths:
@@ -53,6 +54,13 @@ jobs:
         with:
           name: mercury-binaries
           path: ./bin
+
+      # Upload static libs
+      - name: Upload Static Libraries for workflow_call
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-libs
+          path: ./static_libs
 
   Run-Linux-Tests:
     needs: Build

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -14,21 +14,15 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.MERCURY_BOT_APP_ID }}
-          private-key: ${{ secrets.MERCURY_BOT_KEY }}
-
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.MERCURY_PAT }}
           fetch-depth: 0
 
       - name: Set User
         run: |
-          git config user.name "Mercury Actions Bot"
-          git config user.email "228363331+mercury-actions-bot[bot]@users.noreply.github.com"
+          git config user.name "Mercury Release Workflow"
+          git config user.email "mercury-release-workflow@users.noreply.github.com"
 
       # Download binaries
       - uses: actions/download-artifact@v4
@@ -64,7 +58,7 @@ jobs:
       - name: Delete Existing Release If Exists
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -86,7 +80,7 @@ jobs:
       # Create GitHub Release
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           SUMMARY_FILE=$(ls ./releases/SUMMARY_*.md | head -n1)
@@ -109,7 +103,7 @@ jobs:
       # Commit updated docs
       - name: Create Release Update Branch
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           # Create branch & commit
           git checkout -b release-update-${{ steps.version.outputs.version }}
@@ -120,17 +114,17 @@ jobs:
 
       - name: Create PR
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           gh pr create \
-            --title "Update release metadata for ${{ steps.version.outputs.version }}" \
+            --title "[Website] Bump Release ${{ steps.version.outputs.version }}" \
             --body "Automated update of release metadata." \
             --base main \
             --head release-update-${{ steps.version.outputs.version }}
 
       - name: Approve and Merge PR
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           PR_NUMBER=$(gh pr list --head release-update-${{ steps.version.outputs.version }} --json number -q '.[0].number')
           gh pr review $PR_NUMBER --approve
@@ -138,7 +132,7 @@ jobs:
 
       - name: Delete Release Update Branch
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           BRANCH="release-update-${{ steps.version.outputs.version }}"
           git push origin --delete "$BRANCH" || echo "Branch already deleted"

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -127,7 +127,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERCURY_PAT }}
         run: |
           PR_NUMBER=$(gh pr list --head release-update-${{ steps.version.outputs.version }} --json number -q '.[0].number')
-          gh pr review $PR_NUMBER --approve
           gh pr merge $PR_NUMBER --merge --admin
 
       - name: Delete Release Update Branch

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -119,9 +119,10 @@ jobs:
         run: |
           gh pr create \
             --title "[Website] Bump Release ${{ steps.version.outputs.version }}" \
-            --body "Automated update of release metadata." \
+            --body "Automated release bump for ${{ steps.version.outputs.version }}." \
             --base main \
-            --head release-update-${{ steps.version.outputs.version }}
+            --head release-update-${{ steps.version.outputs.version }} \
+            --label "website,repo,top-priority"
 
       - name: Approve and Merge PR
         env:

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -1,0 +1,144 @@
+name: Make Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.MERCURY_BOT_APP_ID }}
+          private-key: ${{ secrets.MERCURY_BOT_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Set User
+        run: |
+          git config user.name "Mercury Actions Bot"
+          git config user.email "228363331+mercury-actions-bot[bot]@users.noreply.github.com"
+
+      # Download binaries
+      - uses: actions/download-artifact@v4
+        with:
+          name: mercury-binaries
+          path: ./bin
+
+      # Download static libs
+      - uses: actions/download-artifact@v4
+        with:
+          name: static-libs
+          path: ./static_libs
+
+      # Make executables
+      - name: Make Executable Shell Scripts
+        run: chmod +x ./build_tools/*.sh
+
+      # Run release builder
+      - name: Make Release
+        run: |
+          make -t all # Force to be up-to-date
+          make static_deps
+          make release
+
+      # Read version from version.txt
+      - name: Extract Version
+        id: version
+        run: |
+          VERSION=$(sed 's/^Mercury //' version.txt)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Delete existing release if it exists
+      - name: Delete Existing Release If Exists
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          echo "Cleaning up release and tag for $VERSION"
+
+          # Delete release if it exists
+          gh release delete "$VERSION" -y || echo "No release to delete"
+
+          # Delete remote tag if it exists
+          git push origin ":refs/tags/$VERSION" || echo "No remote tag to delete"
+
+          # Delete local tag if it exists
+          git tag -d "$VERSION" || echo "No local tag to delete"
+
+          # Confirm cleanup
+          gh release list --limit 5
+          git ls-remote --tags origin | grep "$VERSION" || echo "Remote tag is gone"
+
+      # Create GitHub Release
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SUMMARY_FILE=$(ls ./releases/SUMMARY_*.md | head -n1)
+          TAR_FILE=$(ls ./releases/*.tar.gz | head -n1)
+          ZIP_FILE=$(ls ./releases/*.zip | head -n1)
+
+          # Determine if this is a pre-release (v0.*.*)
+          if [[ "$VERSION" =~ ^v0\.[0-9]+\.[0-9]+$ ]]; then
+            PRERELEASE="--prerelease"
+          else
+            PRERELEASE=""
+          fi
+
+          # Create release (tag is the version only, title keeps "Mercury vX.X.X")
+          gh release create "$VERSION" "$TAR_FILE" "$ZIP_FILE" \
+            --title "Mercury $VERSION" \
+            --notes-file "$SUMMARY_FILE" \
+            $PRERELEASE
+
+      # Commit updated docs
+      - name: Create Release Update Branch
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Create branch & commit
+          git checkout -b release-update-${{ steps.version.outputs.version }}
+          git add docs/releases.json docs/latest
+          git commit -m "Update release metadata for ${{ steps.version.outputs.version }}" || echo "No changes to commit"
+          git restore .
+          git push origin HEAD
+
+      - name: Create PR
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr create \
+            --title "Update release metadata for ${{ steps.version.outputs.version }}" \
+            --body "Automated update of release metadata." \
+            --base main \
+            --head release-update-${{ steps.version.outputs.version }}
+
+      - name: Approve and Merge PR
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --head release-update-${{ steps.version.outputs.version }} --json number -q '.[0].number')
+          gh pr review $PR_NUMBER --approve
+          gh pr merge $PR_NUMBER --merge --admin
+
+      - name: Delete Release Update Branch
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="release-update-${{ steps.version.outputs.version }}"
+          git push origin --delete "$BRANCH" || echo "Branch already deleted"

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           token: ${{ secrets.MERCURY_PAT }}
           fetch-depth: 0
+          ref: main
 
       - name: Set User
         run: |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     - [Linux & Windows Builds](#linux--windows-builds)
     - [TLS Certs](#tls-certs)
     - [Compatibility](#compatibility)
+    - [Making Releases](#making-releases)
 - [Testing Suite](#testing-suite)
 - [Contributing](#contributing)
     - [Creating Issues & Pull Requests](#creating-issues--pull-requests)
@@ -67,6 +68,12 @@ Thus, almost any Linux environment with the following g++ and mingw-w64 versions
 |-----------|------------|
 | g++       | 13.3.0     |
 | mingw-w64 | 11.0.1     |
+
+### Making Releases
+
+To build a release, manually dispatch the "Make Release" GitHub Action to automatically build the binaries, test them, then bundle the release and push it to the downloads website.
+
+While a release can be manually made locally (via `make release`), this process is now automated and should only be done by dispatching this workflow.
 
 ## Testing Suite
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ To build a release, manually dispatch the "Make Release" GitHub Action to automa
 
 While a release can be manually made locally (via `make release`), this process is now automated and should only be done by dispatching this workflow.
 
+**NOTE**: the "Make Release" workflow will take the most recent changes on main and bundle them with the version committed to main. If you are building a release from a work-in-progress branch, *don't*.
+Please refrain from building a release from commits not yet pushed to main--any such releases will be removed and your contributorship will be reconsidered.
+
 ## Testing Suite
 
 This project has its own Python test runner complete with passes for IPv4 & IPv6 traffic with and without TLS enabled.


### PR DESCRIPTION
## About
This PR will merge the GitHub Actions workflow that can automatically build, test, and create releases from any commits pushed to main. While the workflow can only be manually dispatched, this is the intended behavior. Now once this workflow is triggered, the release will be automatically generated and the website will update.

The creation of this script prevents individual users' systems from being the point of build for any binary, reducing the associated risk and centralizing the production builds to an impartial cloud server, not a development device.