### PR TITLE
[Bug] Various Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.13.1
+- Fix Response object headers not being overwritten if multiple of the same name are applied in succession
+    - This causes the default MIME type for PHP scripts to not function as intended
+- Add lazy MIME inferring for PHP CGI responses
+- Removed extra debug log in CGI client
+- Fixed HEAD requests w/ PHP-FPM returning no body internally
+    - Resulted in Content-Length of 0 and broke early type inferring
+- Now applies Match node headers for PHP files
+
 ## v0.13.0
 - PHP CGI improvements (#110)
     - Now initially sets the Content-Type if not received from PHP CGI (as fallback)

--- a/src/http/response.hpp
+++ b/src/http/response.hpp
@@ -16,6 +16,7 @@ namespace http {
             void setStatus(const uint16_t statusCode);
             inline uint16_t getStatus() const { return httpVersion == "HTTP/0.9" ? 0 : statusCode; };
             void setHeader(std::string name, const std::string& value);
+            void clearHeader(std::string);
 
             int loadBodyFromErrorDoc(const uint16_t statusCode);
             int loadBodyFromFile(File& file);
@@ -26,6 +27,7 @@ namespace http {
                 this->setHeader("Content-Type", type);
             }
             const std::string getContentType() const;
+            int getContentLength() const;
 
             void loadToBuffer(std::string& buffer, const bool omitBody);
         private:

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -47,6 +47,13 @@ namespace http {
                     // Check for PHP files
                     if (conf::USE_PHP_FPM && file.path.ends_with(".php")) {
                         fcgi::handlePHPRequest(file, request, *pResponse);
+
+                        // Load additional headers
+                        for (conf::Match* pMatch : conf::matchConfigs)
+                            if (std::regex_match(file.path, pMatch->getPattern()))
+                                for (auto [name, value] : pMatch->getHeaders())
+                                    pResponse->setHeader(name, value);
+
                         return pResponse;
                     }
                 }
@@ -84,7 +91,10 @@ namespace http {
 
                         // Otherwise, body loaded successfully
                         pResponse->setStatus(200);
-                        pResponse->setHeader("Content-Type", file.MIME);
+
+                        // Set MIME if there is content to return
+                        if (pResponse->getContentLength() > 0)
+                            pResponse->setHeader("Content-Type", file.MIME);
 
                         // Load additional headers for body loading
                         for (conf::Match* pMatch : conf::matchConfigs)

--- a/src/util/string_tools.cpp
+++ b/src/util/string_tools.cpp
@@ -96,3 +96,13 @@ int compressText(std::string& buffer, const int method) {
     }
     return IO_SUCCESS;
 }
+
+bool isMostlyAscii(const std::string& data, double thresh) {
+    int asciiCount = 0;
+
+    for (const unsigned char c : data)
+        if ((c >= 0x20 && c <= 0x7E) || c == '\n' || c == '\r' || c == '\t')
+            ++asciiCount;
+
+    return (double)asciiCount / data.size() >= thresh;
+}

--- a/src/util/string_tools.hpp
+++ b/src/util/string_tools.hpp
@@ -28,4 +28,6 @@ void formatHeaderCasing(std::string&);
 
 int compressText(std::string&, const int);
 
+bool isMostlyAscii(const std::string&, double=0.95);
+
 #endif

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.13.0
+Mercury v0.13.1


### PR DESCRIPTION
## About
I found a number of bug fixes since releasing v0.13.0 a few hours ago, here is a CHANGELOG snippet of the changes I've made.

- Fix Response object headers not being overwritten if multiple of the same name are applied in succession
    - This causes the default MIME type for PHP scripts to not function as intended
- Add lazy MIME inferring for PHP CGI responses
- Removed extra debug log in CGI client
- Fixed HEAD requests w/ PHP-FPM returning no body internally
    - Resulted in Content-Length of 0 and broke early type inferring
- Now applies Match node headers for PHP files