### PR TITLE
[Bug] Fix PHP Setup for Release Maker

### DIFF
--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Make Executable Shell Scripts
         run: chmod +x ./build_tools/*.sh
 
+      # Setup PHP for Windows
+      - name: Setup PHP for Windows
+        run: make win_php
+
       # Run release builder
       - name: Make Release
         run: |


### PR DESCRIPTION
## About
After merging #125, I've introduced a bug for setting up PHP in the release maker workflow. This bug fixes the issue as PHP is no longer in the repository tree.