### PR TITLE
[Feature] Reduced Excessive Header Cluttering

### DIFF
--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -1,5 +1,11 @@
 #include "conf.hpp"
 
+#include <iostream>
+
+#include "../io/file_tools.hpp"
+#include "../util/string_tools.hpp"
+#include "../../lib/pugixml.hpp"
+
 /****** EXTERNAL FIELDS ******/
 
 namespace conf {
@@ -222,7 +228,7 @@ int loadConfig() {
 
     for (pugi::xml_node& match : matchNodes) {
         // Parse match
-        Match* pMatch = loadMatch(match);
+        Match* pMatch = conf::loadMatch(match);
         if (pMatch == nullptr) return CONF_FAILURE;
         matchConfigs.push_back(pMatch);
     }

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -1,14 +1,8 @@
 #ifndef __CONF_HPP
 #define __CONF_HPP
 
-#include <iostream>
-
 #include "../pch/common.hpp"
-#include "../io/file_tools.hpp"
-#include "../util/string_tools.hpp"
 #include "conf_match.hpp"
-
-#include "../../lib/pugixml.hpp"
 
 #define CONF_SUCCESS 0
 #define CONF_FAILURE 1

--- a/src/conf/conf_match.cpp
+++ b/src/conf/conf_match.cpp
@@ -1,5 +1,9 @@
 #include "conf_match.hpp"
 
+#include <iostream>
+
+#include "../util/string_tools.hpp"
+
 namespace conf {
 
     Match::Match(const std::string& pattern) {

--- a/src/conf/conf_match.hpp
+++ b/src/conf/conf_match.hpp
@@ -1,12 +1,9 @@
 #ifndef __CONF_MATCH_HPP
 #define __CONF_MATCH_HPP
 
-#include <iostream>
 #include <regex>
 
 #include "../pch/common.hpp"
-#include "../util/string_tools.hpp"
-
 #include "../../lib/pugixml.hpp"
 
 namespace conf {

--- a/src/http/body_stream.cpp
+++ b/src/http/body_stream.cpp
@@ -1,5 +1,11 @@
 #include "body_stream.hpp"
-#include <iostream>
+
+#include <cstring>
+
+#include "../conf/conf.hpp"
+#include "../logs/logger.hpp"
+#include "../util/string_tools.hpp"
+#include "../io/file_tools.hpp"
 
 namespace http {
 

--- a/src/http/body_stream.hpp
+++ b/src/http/body_stream.hpp
@@ -1,17 +1,12 @@
 #ifndef __HTTP_BODY_STREAM_HPP
 #define __HTTP_BODY_STREAM_HPP
 
-#include <cstring>
 #include <fstream>
 #include <string>
 #include <vector>
 
 #include <brotli/encode.h>
 #include <zlib.h>
-
-#include "../conf/conf.hpp"
-#include "../logs/logger.hpp"
-#include "../util/string_tools.hpp"
 
 #define STREAM_SUCCESS 0
 #define STREAM_FAILURE 1

--- a/src/http/cgi/process.cpp
+++ b/src/http/cgi/process.cpp
@@ -1,7 +1,22 @@
 #include "process.hpp"
 
-// Platform specifics
+#ifdef _WIN32
+    #include "../../winheader.hpp"
+#else
+    #include <fcntl.h>
+    #include <sys/types.h>
+    #include <sys/wait.h>
+    #include <unistd.h>
+#endif
 
+#include <map>
+
+#include "../../conf/conf.hpp"
+#include "../../logs/logger.hpp"
+#include "../../util/string_tools.hpp"
+#include "../../util/toolbox.hpp"
+
+// Platform specifics
 namespace http::cgi {
 
     // Lazily infer Content-Type

--- a/src/http/cgi/process.hpp
+++ b/src/http/cgi/process.hpp
@@ -1,24 +1,10 @@
 #ifndef __HTTP_CGI_PROCESS_HPP
 #define __HTTP_CGI_PROCESS_HPP
 
-#include <condition_variable>
-#include <map>
-#include <mutex>
-
 #include "../../pch/common.hpp"
-
-#ifdef _WIN32
-    #include "../../winheader.hpp"
-#else
-    #include <fcntl.h>
-    #include <sys/types.h>
-    #include <sys/wait.h>
-    #include <unistd.h>
-#endif
 
 #include "../request.hpp"
 #include "../response.hpp"
-#include "../../logs/logger.hpp"
 
 // Platform specifics
 

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -1,5 +1,10 @@
 #include "request.hpp"
 
+#include "exception.hpp"
+#include "../conf/conf.hpp"
+#include "../util/string_tools.hpp"
+#include "../util/toolbox.hpp"
+
 namespace http {
 
     void loadEarlyHeaders(headers_map_t& headers, const std::string& partialReq) {

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -1,13 +1,9 @@
 #ifndef __HTTP_REQUEST_HPP
 #define __HTTP_REQUEST_HPP
 
-#include <chrono>
-
 #include "../pch/common.hpp"
 
 #include "response.hpp"
-#include "exception.hpp"
-#include "../util/toolbox.hpp"
 
 namespace http {
 

--- a/src/http/response.cpp
+++ b/src/http/response.cpp
@@ -1,5 +1,11 @@
 #include "response.hpp"
 
+#include <format>
+
+#include "../logs/logger.hpp"
+#include "../io/file_tools.hpp"
+#include "../util/toolbox.hpp"
+
 #define CRLF "\r\n"
 
 namespace http {

--- a/src/http/response.hpp
+++ b/src/http/response.hpp
@@ -5,10 +5,13 @@
 #include <functional>
 #include <memory>
 
+#ifdef _WIN32
+    #include "../winheader.hpp"
+#endif
+
 #include "../pch/common.hpp"
 #include "../io/file.hpp"
-#include "../util/toolbox.hpp"
-#include "../logs/logger.hpp"
+#include "../util/string_tools.hpp"
 #include "body_stream.hpp"
 
 // The minimum size for a body to be compressed

--- a/src/http/server-ipv6.cpp
+++ b/src/http/server-ipv6.cpp
@@ -1,5 +1,7 @@
 #include "server-ipv6.hpp"
 
+#include "../logs/logger.hpp"
+
 namespace http {
 
     int bindSocketOpts(ServerV6& server, int& sock, const bool logErrors) {

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -1,5 +1,20 @@
 #include "server.hpp"
 
+#include "../io/file.hpp"
+#include "../logs/logger.hpp"
+#include "../util/string_tools.hpp"
+#include "../util/toolbox.hpp"
+
+#include "exception.hpp"
+#include "version/handler_1_1.hpp"
+#include "version/handler_1_0.hpp"
+#include "version/handler_0_9.hpp"
+
+#define SOCKET_DRAIN_BUFFER_SIZE 8192
+
+#define KEEP_ALIVE_TIMEOUT_MS 3000
+#define KEEP_ALIVE_MAX_REQ 100
+
 namespace http {
 
     Server::Server(const port_t port, const bool useTLS) : port(port),

--- a/src/http/server.hpp
+++ b/src/http/server.hpp
@@ -19,27 +19,13 @@
 #include "request.hpp"
 #include "response.hpp"
 #include "tls.hpp"
-#include "../io/file.hpp"
-#include "../util/toolbox.hpp"
 #include "../util/thread_pool.hpp"
-#include "../logs/logger.hpp"
-
-#include "version/handler_1_1.hpp"
-#include "version/handler_1_0.hpp"
-#include "version/handler_0_9.hpp"
-
-#include <zlib.h>
-
-#define SOCKET_DRAIN_BUFFER_SIZE 8192
 
 #define SOCKET_UNSET -1
 
 #define SOCKET_FAILURE 1
 #define BIND_FAILURE 2
 #define LISTEN_FAILURE 3
-
-#define KEEP_ALIVE_TIMEOUT_MS 3000
-#define KEEP_ALIVE_MAX_REQ 100
 
 namespace http {
 

--- a/src/http/tls.cpp
+++ b/src/http/tls.cpp
@@ -1,5 +1,7 @@
 #include "tls.hpp"
 
+#include <string>
+
 SSL_CTX* initTLSContext() {
     OPENSSL_no_config();
 

--- a/src/http/tls.hpp
+++ b/src/http/tls.hpp
@@ -1,8 +1,6 @@
 #ifndef __TLS_HPP
 #define __TLS_HPP
 
-#include <string>
-
 #include <openssl/ssl.h>
 
 #include "../conf/conf.hpp"

--- a/src/http/version/handler_0_9.cpp
+++ b/src/http/version/handler_0_9.cpp
@@ -1,5 +1,8 @@
 #include "handler_0_9.hpp"
 
+#include "../../conf/conf.hpp"
+#include "../../util/toolbox.hpp"
+
 namespace http::version::handler_0_9 {
 
     Response* genResponse(Request& request) {

--- a/src/http/version/handler_0_9.hpp
+++ b/src/http/version/handler_0_9.hpp
@@ -4,8 +4,6 @@
 #include "../request.hpp"
 #include "../response.hpp"
 
-#include "../cgi/process.hpp"
-
 namespace http::version::handler_0_9 {
     Response* genResponse(Request&);
 }

--- a/src/http/version/handler_1_0.cpp
+++ b/src/http/version/handler_1_0.cpp
@@ -1,5 +1,8 @@
 #include "handler_1_0.hpp"
 
+#include "../../conf/conf.hpp"
+#include "../../util/toolbox.hpp"
+
 #define ALLOWED_STATIC_METHODS "GET, HEAD"
 
 namespace http {

--- a/src/http/version/handler_1_0.hpp
+++ b/src/http/version/handler_1_0.hpp
@@ -4,8 +4,6 @@
 #include "../request.hpp"
 #include "../response.hpp"
 
-#include "../cgi/process.hpp"
-
 namespace http::version::handler_1_0 {
     Response* genResponse(Request&);
 }

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -1,5 +1,9 @@
 #include "handler_1_1.hpp"
 
+#include "../cgi/process.hpp"
+#include "../../conf/conf.hpp"
+#include "../../util/toolbox.hpp"
+
 #define ALLOWED_STATIC_METHODS "GET, HEAD, OPTIONS"
 #define ALLOWED_METHODS "GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE"
 

--- a/src/http/version/handler_1_1.hpp
+++ b/src/http/version/handler_1_1.hpp
@@ -4,8 +4,6 @@
 #include "../request.hpp"
 #include "../response.hpp"
 
-#include "../cgi/process.hpp"
-
 namespace http::version::handler_1_1 {
     Response* genResponse(Request&);
 }

--- a/src/http/version_checker.cpp
+++ b/src/http/version_checker.cpp
@@ -1,5 +1,20 @@
 #include "version_checker.hpp"
 
+#include <cstring>
+#include <iostream>
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#ifdef _WIN32
+    #include "../winheader.hpp"
+#else
+    #include <arpa/inet.h>
+    #include <netdb.h>
+    #include <sys/socket.h>
+    #include <unistd.h>
+#endif
+
 #ifdef _WIN32
     #define close closesocket
 #endif

--- a/src/http/version_checker.hpp
+++ b/src/http/version_checker.hpp
@@ -1,21 +1,7 @@
 #ifndef __HTTP_VERSION_CHECKER_HPP
 #define __HTTP_VERSION_CHECKER_HPP
 
-#include <cstring>
-#include <iostream>
 #include <string>
-
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-
-#ifdef _WIN32
-    #include "../winheader.hpp"
-#else
-    #include <arpa/inet.h>
-    #include <netdb.h>
-    #include <sys/socket.h>
-    #include <unistd.h>
-#endif
 
 // Used to fetch the latest version from remote
 std::string fetchLatestVersion();

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -1,5 +1,8 @@
 #include "file.hpp"
 
+#include "../io/file_tools.hpp"
+#include "../util/toolbox.hpp"
+
 File::File(const std::string& rawPath) {
     this->rawPath = rawPath;
     size_t queryIndex = rawPath.find('?');

--- a/src/io/file.hpp
+++ b/src/io/file.hpp
@@ -2,7 +2,6 @@
 #define __FILE_HPP
 
 #include "../pch/common.hpp"
-#include "../util/toolbox.hpp"
 #include "../http/body_stream.hpp"
 
 #define MIME_UNSET ""

--- a/src/io/file_tools.cpp
+++ b/src/io/file_tools.cpp
@@ -1,5 +1,14 @@
 #include "file_tools.hpp"
 
+#ifdef _WIN32
+    #include "../winheader.hpp"
+#endif
+
+#include <iostream>
+#include <random>
+
+#include "../logs/logger.hpp"
+
 #define TMP_FILE_MAX_RETRIES 50
 #define TMP_FILE_NAME_LEN 12
 

--- a/src/io/file_tools.hpp
+++ b/src/io/file_tools.hpp
@@ -1,14 +1,7 @@
 #ifndef __FILE_TOOLS_HPP
 #define __FILE_TOOLS_HPP
 
-#include <random>
-
 #include "../pch/common.hpp"
-#include "../logs/logger.hpp"
-
-#ifdef _WIN32
-    #include "../winheader.hpp"
-#endif
 
 // Including conf.hpp technically is a cyclical header but it doesn't introduce any errors
 // Needed for conf::DOCUMENT_ROOT

--- a/src/logs/logger.cpp
+++ b/src/logs/logger.cpp
@@ -1,5 +1,10 @@
 #include "logger.hpp"
 
+#include <iomanip>
+
+#include "../pch/common.hpp"
+#include "../conf/conf.hpp"
+
 Logger::Logger() : isExited(false) {
     // Create thread
     this->thread = std::thread(&Logger::threadWrite, this);

--- a/src/logs/logger.hpp
+++ b/src/logs/logger.hpp
@@ -3,12 +3,8 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <iomanip>
 #include <mutex>
 #include <ostream>
-
-#include "../pch/common.hpp"
-#include "../conf/conf.hpp"
 
 #define ACCESS_LOG Logger::getInstance()(true)
 #define ERROR_LOG Logger::getInstance()(false)

--- a/src/util/string_tools.hpp
+++ b/src/util/string_tools.hpp
@@ -5,12 +5,6 @@
 
 #include "../pch/common.hpp"
 
-#include <zlib.h>
-
-#define IO_SUCCESS 0
-#define IO_FAILURE 1
-#define IO_ABORTED 2
-
 #define COMPRESS_DEFLATE 0
 #define COMPRESS_GZIP 1
 #define COMPRESS_BROTLI 2

--- a/src/util/toolbox.cpp
+++ b/src/util/toolbox.cpp
@@ -1,5 +1,16 @@
 #include "toolbox.hpp"
 
+#include <chrono>
+#include <iomanip>
+
+#ifdef _WIN32
+    #include "../winheader.hpp"
+#endif
+
+#include "string_tools.hpp"
+#include "../conf/conf.hpp"
+#include "../pch/common.hpp"
+
 int loadErrorDoc(const int status, std::unique_ptr<http::IBodyStream>& pStream) {
     std::string buffer;
     std::filesystem::path cwd = conf::CWD / "conf" / "html" / "err.html";

--- a/src/util/toolbox.hpp
+++ b/src/util/toolbox.hpp
@@ -1,17 +1,11 @@
 #ifndef __TOOLBOX_HPP
 #define __TOOLBOX_HPP
 
-#include <chrono>
-#include <iomanip>
-
-#ifdef _WIN32
-    #include "../winheader.hpp"
-#endif
-
-#include "../pch/common.hpp"
-#include "string_tools.hpp"
-#include "../conf/conf.hpp"
 #include "../http/body_stream.hpp"
+
+#define IO_SUCCESS 0
+#define IO_FAILURE 1
+#define IO_ABORTED 2
 
 void formatFileSize(size_t, std::string&);
 void formatDate(const std::chrono::system_clock::duration, std::string&);


### PR DESCRIPTION
## About
In response to issue #138, I've improved the Mercury compile time by reducing the amount of headers included in each header (now headers are included in implementation files where applicable). This resulted in an average ~1.22x increase in compilation time, which is certainly not nothing!