### PR TITLE
[Bug] Fix v0.15.0 Release

### DIFF
--- a/docs/latest
+++ b/docs/latest
@@ -1,1 +1,1 @@
-Mercury v0.15.1
+Mercury v0.15.0

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -1,15 +1,9 @@
 [
     {
-        "name": "v0.15.1",
-        "date": 1757292116323,
-        "linuxHash": "ee505f90d2d25085b1f98b34adc54c7d5d4e020b8a1081ebc4e434dc4732e69d",
-        "winHash": "08e0845e4066241fba07660ddd6e1c8822c1b3560048189c53c684d72b7fa17e"
-    },
-    {
         "name": "v0.15.0",
-        "date": 1757290472006,
-        "linuxHash": "b191a008a26c572b74f83908e2a0d39f3459d83d073c2ccbb678f114f35e0dd4",
-        "winHash": "46327242ad61f155346f94fe9ef50401f5680063b8c01fddb721f6dce08a3fcb"
+        "date": 1757296086692,
+        "linuxHash": "76648f31c97d6df7242555c20874a294bfc4b90eb6352124da3841acb80a014c",
+        "winHash": "9dba166f5cbb04af572483ad6b3dbfc7a4d04ba3f9de737e541fd8d2ef012791"
     },
     {
         "name": "v0.14.0",


### PR DESCRIPTION
## About
When I released v0.15.1 (#152), I forgot to update version.txt, which caused the release maker Action to overwrite the release. This patches this issue, although I'll need to remake v0.15.1 release.