### PR TITLE
[Feature] Config Loader Bump w/ Release v0.16.0

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -35,7 +35,6 @@ jobs:
           # Update conf/mercury.conf
           sed -i "s|<Port>[[:space:]]*[0-9]\+[[:space:]]*</Port>|<Port> $port </Port>|" conf/mercury.conf
           sed -i "s|<TLSPort>[[:space:]]*.*[[:space:]]*</TLSPort>|<TLSPort> $sslPort </TLSPort>|" conf/mercury.conf
-          sed -i "s|<EnableIPv6>[[:space:]]*off[[:space:]]*</EnableIPv6>|<EnableIPv6> on </EnableIPv6>|" conf/mercury.conf
           sed -i "s|<EnablePHPCGI>[[:space:]]*off[[:space:]]*</EnablePHPCGI>|<EnablePHPCGI> on </EnablePHPCGI>|" conf/mercury.conf
 
           # Update tests/run.py

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -35,7 +35,6 @@ jobs:
 
           $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<Port>\s*\d+\s*</Port>', "<Port> $port </Port>")
           $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<TLSPort>\s*.+?\s*</TLSPort>', "<TLSPort> $sslPort </TLSPort>")
-          $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<EnableIPv6>\s*off\s*</EnableIPv6>', '<EnableIPv6> on </EnableIPv6>')
           $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<EnablePHPCGI>\s*off\s*</EnablePHPCGI>', '<EnablePHPCGI> on </EnablePHPCGI>')
 
           Set-Content -Path $filePath -Value $content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - No longer requires ShowDirectoryIndexes node in Match nodes (defaults to true)
 - Fixed Match patterns applying to full file paths, not relative paths
 - Fixed IPv6 client IP resolution on Windows (previously worked only for ::1)
+- Added BindAddressIPv4 and BindAddressIPv6 nodes to control bind address (#122)
+    - Replaced EnableIPv4 and EnableIPv6 nodes
 
 ## v0.15.1
 - Remove unused string compression methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.16.0
+- Refactored & streamlined config loader script (#128)
+
 ## v0.15.1
 - Remove unused string compression methods
 - Remove unused brotli-cpp lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
     - Renamed IndexFile -> IndexFiles
     - Contains a comma-separated list of all index file names to look for, in order left to right
     - Now allows specifying no index file
+- Added Access node w/ Allow & Deny nodes for restricting access (#141)
+- No longer requires ShowDirectoryIndexes node in Match nodes (defaults to true)
+- Fixed Match patterns applying to full file paths, not relative paths
+- Fixed IPv6 client IP resolution on Windows (previously worked only for ::1)
 
 ## v0.15.1
 - Remove unused string compression methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v0.16.0
 - Refactored & streamlined config loader script (#128)
     - Now gracefully handles invalid formatting for lines in mimes.conf
+- Extended index file support to allow multiple files (#137)
+    - Renamed IndexFile -> IndexFiles
+    - Contains a comma-separated list of all index file names to look for, in order left to right
+    - Now allows specifying no index file
 
 ## v0.15.1
 - Remove unused string compression methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.16.0
 - Refactored & streamlined config loader script (#128)
+    - Now gracefully handles invalid formatting for lines in mimes.conf
 
 ## v0.15.1
 - Remove unused string compression methods

--- a/conf/default/mercury.conf
+++ b/conf/default/mercury.conf
@@ -6,6 +6,14 @@
     <DocumentRoot> ./public/ </DocumentRoot>
 
     #
+    # Controls the socket bind addresses for IPv4 and IPv6, or "off" if disabled
+    #   IPv4 Default: 0.0.0.0
+    #   IPv6 Default: ::
+    #
+    <BindAddressIPv4> 0.0.0.0 </BindAddressIPv4>
+    <BindAddressIPv6> :: </BindAddressIPv6>
+
+    #
     # Specifies what port will be used to serve cleartext (non-HTTPS) content
     #   Default: 80
     #
@@ -17,14 +25,6 @@
     #   Default: off
     #
     <TLSPort> off </TLSPort>
-
-    #
-    # Enables or disables IPv4 and IPv6 traffic (either "on" or "off")
-    #   IPv4 Default: on
-    #   IPv6 Default: off
-    #
-    <EnableIPv4> on </EnableIPv4>
-    <EnableIPv6> off </EnableIPv6>
 
     #
     # Enables or disables legacy HTTP versions (HTTP/0.9, HTTP/1.0)

--- a/conf/default/mercury.conf
+++ b/conf/default/mercury.conf
@@ -34,9 +34,10 @@
 
     #
     # Specifies what name for index files will be served when accessing a directory by name
-    #   Default: index.html
+    # The order (left to right) specifies which files will be searched for first, or empty if desired
+    #   Default: index.html, index.htm, index.php
     #
-    <IndexFile> index.html </IndexFile>
+    <IndexFiles> index.html, index.htm, index.php </IndexFiles>
 
     #
     # Specifies where server access & error logs are stored

--- a/conf/default/mercury.conf
+++ b/conf/default/mercury.conf
@@ -62,7 +62,8 @@
     <WinPHPCGIPath> ./php/php-cgi.exe </WinPHPCGIPath>
 
     #
-    # Match allows individual file/directory control over resource access via regex matches
+    # Match allows individual file/directory control over resource access via regex matches.
+    # Note that the pattern matches the relative path received in the HTTP request, not an absolute path.
     #
     <Match pattern=".*">
         #
@@ -76,6 +77,19 @@
         #   Default: on
         #
         <ShowDirectoryIndexes> on </ShowDirectoryIndexes>
+
+        #
+        # Controls access to content, only valid within a Match
+        # The "mode" attribute controls the default policy, either to deny all except for hosts in the
+        #   Allow nodes or to allow all except for hosts in the Deny nodes.
+        # Note that if the mode is set to "deny all" then any Deny nodes are skipped, and vice versa
+        #   for "allow all" and Allow nodes.
+        #   Valid modes: "deny all" | "allow all"
+        #
+        <Access mode="deny all">
+            <Allow> 127.0.0.1 </Allow>
+            <Allow> ::1 </Allow>
+        </Access>
     </Match>
 
     #

--- a/conf/default/mercury.conf
+++ b/conf/default/mercury.conf
@@ -1,6 +1,6 @@
 <Mercury>
     #
-    # Specifies where files are served from
+    # Specifies where files are served from, relative to the Mercury directory
     #   Default: ./public/
     #
     <DocumentRoot> ./public/ </DocumentRoot>

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -198,8 +198,10 @@ namespace conf {
         // If TLS is enabled, grab the port
         USE_TLS = tlsPortRaw != "off";
         try {
+            // Prevent negatives
+            if (tlsPortRaw.size() == 0) throw std::invalid_argument("");
+            if (USE_TLS && tlsPortRaw[0] == '-') throw std::invalid_argument("");
             TLS_PORT = USE_TLS ? std::stoul(tlsPortRaw) : 0;
-            if (USE_TLS && TLS_PORT == 0) throw std::invalid_argument("");
         } catch (std::invalid_argument&) {
             std::cerr << "Failed to parse config file, invalid value for TLSPort." << std::endl;
             return CONF_FAILURE;
@@ -271,6 +273,10 @@ namespace conf {
         trimString(valueStr);
 
         try {
+            // Prevent negatives
+            if (valueStr.size() == 0) throw std::invalid_argument("");
+            if (valueStr[0] == '-') throw std::invalid_argument("");
+
             var = std::stoull(valueStr);
             if (!allowZero && var == 0) throw std::invalid_argument("");
         } catch (std::invalid_argument&) {
@@ -293,6 +299,10 @@ namespace conf {
         trimString(valueStr);
 
         try {
+            // Prevent negatives
+            if (valueStr.size() == 0) throw std::invalid_argument("");
+            if (valueStr[0] == '-') throw std::invalid_argument("");
+
             var = std::stoul(valueStr);
             if (!allowZero && var == 0) throw std::invalid_argument("");
         } catch (std::invalid_argument&) {

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -67,7 +67,7 @@ namespace conf {
         pugi::xml_parse_result result = doc.load_file(CONF_FILE);
 
         if (!result) {
-            std::cerr << "Failed to open config file.\n";
+            std::cerr << "Failed to open config file." << std::endl;
             return CONF_FAILURE;
         }
 
@@ -85,7 +85,7 @@ namespace conf {
         // Extract root node
         pugi::xml_node root = doc.child("Mercury");
         if (!root) {
-            std::cerr << "Failed to parse config file, missing root node.\n";
+            std::cerr << "Failed to parse config file, missing root \"Mercury\" node." << std::endl;
             return CONF_FAILURE;
         }
 
@@ -122,6 +122,7 @@ namespace conf {
             return CONF_FAILURE;
 
         /************************** Extract IndexFile **************************/
+
         pugi::xml_node indexFileNode = root.child("IndexFile");
         if (!indexFileNode) {
             std::cerr << "Failed to parse config file, missing IndexFile node.\n";
@@ -131,7 +132,7 @@ namespace conf {
         INDEX_FILE = indexFileNode.text().as_string();
         trimString(INDEX_FILE);
 
-        if (!INDEX_FILE.size() || INDEX_FILE.find('/') != std::string::npos || INDEX_FILE.find('\\') != std::string::npos) {
+        if (INDEX_FILE.size() == 0 || INDEX_FILE.find('/') != std::string::npos || INDEX_FILE.find('\\') != std::string::npos) {
             std::cerr << "Failed to parse config file, invalid IndexFile value.\n";
             return CONF_FAILURE;
         }
@@ -186,6 +187,7 @@ namespace conf {
             return CONF_FAILURE;
 
         /************************** LOAD TLS **************************/
+
         pugi::xml_node tlsPortNode = root.child("TLSPort");
         if (!tlsPortNode) {
             std::cerr << "Failed to parse config file, missing TLSPort node.\n";
@@ -230,8 +232,6 @@ namespace conf {
     }
 
     int loadMIMES() {
-        using namespace conf;
-
         // Load MIMES
         std::ifstream mimeHandle(MIMES_FILE);
         if (!mimeHandle.is_open()) return CONF_FAILURE;
@@ -239,6 +239,8 @@ namespace conf {
         std::string line, extBuf, mimeBuf;
         while (std::getline(mimeHandle, line)) {
             size_t spaceIndex = line.find(' ');
+            if (spaceIndex == std::string::npos) continue;
+
             extBuf = line.substr(0, spaceIndex);
             mimeBuf = line.substr(spaceIndex+1);
             trimString(extBuf);

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -1,6 +1,8 @@
 #ifndef __CONF_HPP
 #define __CONF_HPP
 
+#include <optional>
+
 #include "../pch/common.hpp"
 #include "conf_match.hpp"
 
@@ -22,8 +24,12 @@ namespace conf {
 
     extern std::filesystem::path DOCUMENT_ROOT;
     extern port_t PORT;
+
     extern bool IS_IPV4_ENABLED;
+    extern std::optional<SanitizedIP> BIND_ADDR_IPV4;
     extern bool IS_IPV6_ENABLED;
+    extern std::optional<SanitizedIP> BIND_ADDR_IPV6;
+
     extern bool ENABLE_LEGACY_HTTP;
     extern unsigned short MAX_REQUEST_BACKLOG;
     extern unsigned int REQUEST_BUFFER_SIZE, RESPONSE_BUFFER_SIZE;

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -30,7 +30,7 @@ namespace conf {
     extern unsigned int MAX_REQUEST_BODY, MAX_RESPONSE_BODY;
     extern unsigned int THREADS_PER_CHILD;
     extern std::vector<conf::Match*> matchConfigs;
-    extern std::string INDEX_FILE;
+    extern std::vector<std::string> INDEX_FILES;
 
     extern std::filesystem::path ACCESS_LOG_FILE;
     extern std::filesystem::path ERROR_LOG_FILE;

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -52,11 +52,9 @@ namespace conf {
     extern std::unordered_map<std::string, std::string> MIMES;
     extern std::filesystem::path CWD;
 
+    // Static methods
+    int loadConfig();
+    void cleanupConfig();
 }
-
-/*****************************/
-
-int loadConfig();
-void cleanupConfig();
 
 #endif

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -29,7 +29,7 @@ namespace conf {
     extern unsigned int REQUEST_BUFFER_SIZE, RESPONSE_BUFFER_SIZE;
     extern unsigned int MAX_REQUEST_BODY, MAX_RESPONSE_BODY;
     extern unsigned int THREADS_PER_CHILD;
-    extern std::vector<conf::Match*> matchConfigs;
+    extern std::vector<std::unique_ptr<Match>> matchConfigs;
     extern std::vector<std::string> INDEX_FILES;
 
     extern std::filesystem::path ACCESS_LOG_FILE;

--- a/src/conf/conf_access.cpp
+++ b/src/conf/conf_access.cpp
@@ -1,0 +1,122 @@
+#include "conf_access.hpp"
+
+#ifdef _WIN32
+    #include "../winheader.hpp"
+#else
+    #include <arpa/inet.h>
+#endif
+
+#include <cstring>
+#include "../util/string_tools.hpp"
+
+namespace conf {
+
+    SanitizedIP::SanitizedIP(const IPFamily ipf, const unsigned int prefixLength) :
+        family(ipf), prefixLength(prefixLength) {
+        std::memset(this->bytes, 0, sizeof(this->bytes));
+    }
+
+    bool doesAddressFitCIDR(const SanitizedIP& cidr, const SanitizedIP& candidate) {
+        if (cidr.family != candidate.family) return false;
+        const int length = cidr.family == IPFamily::IPv4 ? 4 : 16;
+
+        // Match CIDR notation
+        int bitsLeft = cidr.prefixLength;
+        for (int i = 0; i < length && bitsLeft > 0; ++i) {
+            // Mask bytes
+            const uint8_t mask = (bitsLeft >= 8) ? 0xFF : static_cast<uint8_t>(0xFF << (8 - bitsLeft));
+
+            // Compare against mask
+            if ((cidr.bytes[i] & mask) != (candidate.bytes[i] & mask))
+                return false;
+
+            bitsLeft -= (bitsLeft >= 8) ? 8 : bitsLeft;
+        }
+
+        // Base case, success
+        return true;
+    }
+
+    bool Access::isIPAccepted(SanitizedIP& candidate) const {
+        // Check each exception
+        for (const SanitizedIP& cidr : this->exceptions)
+            if (doesAddressFitCIDR(cidr, candidate)) // Check address
+                return this->isDenyFirst;
+
+        // Base case, no exceptions met
+        return !this->isDenyFirst;
+    }
+
+    void Access::insertIP(SanitizedIP ip) {
+        this->exceptions.push_back(ip);
+    }
+
+    SanitizedIP parseSanitizedClientIP(const std::string& clientIP) {
+        // Try IPv4
+        in_addr addr4;
+        if (inet_pton(AF_INET, clientIP.c_str(), &addr4) == 1) {
+            SanitizedIP sip( IPFamily::IPv4, 32 );
+            std::memcpy(sip.bytes, &addr4, 4);
+            return sip;
+        }
+
+        // Try IPv6
+        in6_addr addr6;
+        if (inet_pton(AF_INET6, clientIP.c_str(), &addr6) == 1) {
+            SanitizedIP sip( IPFamily::IPv6, 128 );
+            std::memcpy(sip.bytes, &addr6, 16);
+            return sip;
+        }
+
+        // Base case, invalid IP address
+        throw std::invalid_argument("Invalid IP address");
+    }
+
+    SanitizedIP parseSanitizedIP(const pugi::xml_node& childNode) {
+        // Extract raw string
+        std::string raw = childNode.text().as_string();
+        trimString(raw);
+        if (raw.size() == 0) throw std::invalid_argument("Empty IP address");
+
+        int prefixLength = -1;
+
+        // Extract prefix length, if present
+        const size_t slashIndex = raw.find('/');
+        if (slashIndex != std::string::npos) {
+            prefixLength = static_cast<unsigned int>( std::stoul( raw.substr(slashIndex+1) ) );
+
+            // Remove prefix length
+            while (raw.size() > slashIndex)
+                raw.pop_back();
+        }
+
+        // Extract address
+        // Try IPv4
+        in_addr addr4;
+        if (inet_pton(AF_INET, raw.c_str(), &addr4) == 1) {
+            if (prefixLength == -1) prefixLength = 32;
+            if (prefixLength < 0 || prefixLength > 32)
+                throw std::invalid_argument("Invalid IPv4 prefix length");
+
+            SanitizedIP sip( IPFamily::IPv4, prefixLength );
+            std::memcpy(sip.bytes, &addr4, 4);
+            return sip;
+        }
+
+        // Try IPv6
+        in6_addr addr6;
+        if (inet_pton(AF_INET6, raw.c_str(), &addr6) == 1) {
+            if (prefixLength == -1) prefixLength = 128;
+            if (prefixLength < 0 || prefixLength > 128)
+                throw std::invalid_argument("Invalid IPv6 prefix length");
+            
+            SanitizedIP sip( IPFamily::IPv6, prefixLength );
+            std::memcpy(sip.bytes, &addr6, 16);
+            return sip;
+        }
+
+        // Base case, invalid IP address
+        throw std::invalid_argument("Invalid IP address");
+    }
+
+}

--- a/src/conf/conf_access.hpp
+++ b/src/conf/conf_access.hpp
@@ -1,0 +1,40 @@
+#ifndef __CONF_ACCESS_HPP
+#define __CONF_ACCESS_HPP
+
+#include <string>
+#include <vector>
+
+#include "../../lib/pugixml.hpp"
+
+namespace conf {
+
+    enum class IPFamily { IPv4, IPv6 };
+
+    class SanitizedIP {
+        public:
+            SanitizedIP(const IPFamily ipf, const unsigned int prefixLength);
+
+            const IPFamily family; // Either IPv4 or IPv6
+            uint8_t bytes[16]; // Full IP bytes, only first 4 matter for IPv4
+            const unsigned int prefixLength; // For CIDR notation
+    };
+
+    class Access {
+        public:
+            Access(const std::string& mode) : isDenyFirst(mode == "deny all") {};
+
+            // Returns true if the IP is allowed access by the exceptions list
+            bool isIPAccepted(SanitizedIP& ip) const;
+
+            void insertIP(SanitizedIP ip);
+        private:
+            const bool isDenyFirst;
+            std::vector<SanitizedIP> exceptions;
+    };
+
+    SanitizedIP parseSanitizedClientIP(const std::string& clientIP);
+    SanitizedIP parseSanitizedIP(const pugi::xml_node& childNode);
+
+}
+
+#endif

--- a/src/conf/conf_match.hpp
+++ b/src/conf/conf_match.hpp
@@ -1,8 +1,10 @@
 #ifndef __CONF_MATCH_HPP
 #define __CONF_MATCH_HPP
 
+#include <memory>
 #include <regex>
 
+#include "conf_access.hpp"
 #include "../pch/common.hpp"
 #include "../../lib/pugixml.hpp"
 
@@ -18,13 +20,17 @@ namespace conf {
             const std::regex& getPattern() const;
             bool showDirectoryIndexes() const;
             void setShowDirectoryIndexes(const bool b);
+
+            void setAccessControl(std::unique_ptr<Access> p);
+            const std::unique_ptr<Access>& getAccessControl() const { return pAccess; };
         private:
             std::regex pattern;
             std::unordered_map<std::string, std::string> headers;
             bool _showDirectoryIndexes;
+            std::unique_ptr<Access> pAccess;
     };
 
-    Match* loadMatch(pugi::xml_node&);
+    std::unique_ptr<Match> loadMatch(pugi::xml_node&);
 
 }
 

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -169,7 +169,7 @@ namespace http {
 
         // Handle directory listings
         if (file.isDirectory) {
-            for (conf::Match* pMatch : conf::matchConfigs) {
+            for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
                 if (!pMatch->showDirectoryIndexes() &&
                     std::regex_match(file.path, pMatch->getPattern())) {
                     // Hide the directory index

--- a/src/http/server-ipv6.cpp
+++ b/src/http/server-ipv6.cpp
@@ -60,7 +60,7 @@ namespace http {
                 struct sockaddr_in6 addr = {};
                 addr.sin6_family = AF_INET6;
                 addr.sin6_port = htons(this->port);
-                addr.sin6_addr = in6addr_any;
+                memcpy(&addr.sin6_addr, conf::BIND_ADDR_IPV6->bytes, 16);
 
                 // If bound properly, exit early
                 if (bind(this->sock, (const struct sockaddr*)&addr, sizeof(addr)) >= 0)

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -178,7 +178,7 @@ namespace http {
             if (afType == AF_INET) {
                 strcpy(clientIPStr, inet_ntoa(*(struct in_addr*)addrPtr));
             } else {
-                inet_ntop(AF_INET6, addrPtr, clientIPStr, sizeof(clientIPStr));
+                inet_ntop(AF_INET6, addrPtr, clientIPStr, INET6_ADDRSTRLEN);
             }
         #else
             inet_ntop(afType, addrPtr, clientIPStr, afType == AF_INET6 ? INET6_ADDRSTRLEN : INET_ADDRSTRLEN);

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -70,7 +70,7 @@ namespace http {
         struct sockaddr_in addr;
         addr.sin_family = AF_INET;
         addr.sin_port = htons(this->port);
-        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        memcpy(&addr.sin_addr, conf::BIND_ADDR_IPV4->bytes, 4);
 
         if (bind(this->sock, (const struct sockaddr*)&addr, sizeof(addr)) < 0) {
             #ifdef __linux__

--- a/src/http/version/handler_0_9.cpp
+++ b/src/http/version/handler_0_9.cpp
@@ -2,6 +2,7 @@
 
 #include "../../conf/conf.hpp"
 #include "../../util/toolbox.hpp"
+#include "../../logs/logger.hpp"
 
 namespace http::version::handler_0_9 {
 
@@ -14,6 +15,35 @@ namespace http::version::handler_0_9 {
         if (method != METHOD::GET) {
             pResponse->loadBodyFromErrorDoc(501); // Not Implemented
             return pResponse;
+        }
+
+        // Verify access is permitted
+        if (!conf::matchConfigs.empty()) {
+            // Format raw path & remove query string
+            std::string rawPath = request.getPathStr();
+            const size_t queryIndex = rawPath.find('/');
+            while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
+                rawPath.pop_back();
+
+            // Create sanitized IP address
+            try {
+                conf::SanitizedIP sip( conf::parseSanitizedClientIP(request.getIPStr()) );
+
+                // Check Match patterns
+                for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
+                    if (std::regex_match(rawPath, pMatch->getPattern())) {
+                        // Verify access is permitted
+                        if (!pMatch->getAccessControl()->isIPAccepted(sip)) {
+                            pResponse->loadBodyFromErrorDoc(403);
+                            return pResponse;
+                        }
+                    }
+                }
+            } catch (std::invalid_argument&) {
+                ERROR_LOG << "Invalid IP address while parsing sanitized IP" << std::endl;
+                pResponse->loadBodyFromErrorDoc(500);
+                return pResponse;
+            }
         }
 
         // Verify path is restricted to document root

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -3,6 +3,7 @@
 #include "../cgi/process.hpp"
 #include "../../conf/conf.hpp"
 #include "../../util/toolbox.hpp"
+#include "../../logs/logger.hpp"
 
 #define ALLOWED_STATIC_METHODS "GET, HEAD, OPTIONS"
 #define ALLOWED_METHODS "GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE"
@@ -36,6 +37,35 @@ namespace http {
                     return pResponse;
                 }
 
+                // Verify access is permitted
+                if (!conf::matchConfigs.empty()) {
+                    // Format raw path & remove query string
+                    std::string rawPath = request.getPathStr();
+                    const size_t queryIndex = rawPath.find('/');
+                    while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
+                        rawPath.pop_back();
+
+                    // Create sanitized IP address
+                    try {
+                        conf::SanitizedIP sip( conf::parseSanitizedClientIP(request.getIPStr()) );
+
+                        // Check Match patterns
+                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
+                            if (std::regex_match(rawPath, pMatch->getPattern())) {
+                                // Verify access is permitted
+                                if (!pMatch->getAccessControl()->isIPAccepted(sip)) {
+                                    setStatusMaybeErrorDoc(request, *pResponse, 403);
+                                    return pResponse;
+                                }
+                            }
+                        }
+                    } catch (std::invalid_argument&) {
+                        ERROR_LOG << "Invalid IP address while parsing sanitized IP (" << request.getIPStr() << ')' << std::endl;
+                        setStatusMaybeErrorDoc(request, *pResponse, 500);
+                        return pResponse;
+                    }
+                }
+
                 // Verify the body (which is ignored in the Request object) wasn't too large
                 if (request.isContentTooLarge()) {
                     setStatusMaybeErrorDoc(request, *pResponse, 413);
@@ -59,8 +89,8 @@ namespace http {
                         cgi::handlePHPRequest(file, request, *pResponse);
 
                         // Load additional headers
-                        for (conf::Match* pMatch : conf::matchConfigs)
-                            if (std::regex_match(file.path, pMatch->getPattern()))
+                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
+                            if (std::regex_match(file.rawPath, pMatch->getPattern()))
                                 for (auto [name, value] : pMatch->getHeaders())
                                     pResponse->setHeader(name, value);
 
@@ -107,8 +137,8 @@ namespace http {
                             pResponse->setHeader("Content-Type", file.MIME);
 
                         // Load additional headers for body loading
-                        for (conf::Match* pMatch : conf::matchConfigs)
-                            if (std::regex_match(file.path, pMatch->getPattern()))
+                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
+                            if (std::regex_match(file.rawPath, pMatch->getPattern()))
                                 for (auto [name, value] : pMatch->getHeaders())
                                     pResponse->setHeader(name, value);
                         break;

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -41,9 +41,14 @@ File::File(const std::string& rawPath) {
     }
 
     // Check for index file
-    if (this->path.back() == '/' && std::filesystem::exists(this->path + conf::INDEX_FILE) &&
-        !std::filesystem::is_directory(this->path + conf::INDEX_FILE)) {
-        this->path += conf::INDEX_FILE;
+    if (this->path.back() == '/') {
+        for (const std::string& indexFile : conf::INDEX_FILES) {
+            if (std::filesystem::exists(this->path + indexFile) &&
+                !std::filesystem::is_directory(this->path + indexFile)) {
+                this->path += indexFile;
+                break;
+            }
+        }
     }
 
     // Handle the MIME type if this is a directory

--- a/src/io/file_tools.cpp
+++ b/src/io/file_tools.cpp
@@ -169,7 +169,6 @@ bool createTempFile(std::string& outPath) {
     } while (++i < TMP_FILE_MAX_RETRIES && std::filesystem::exists(outPath));
 
     // Return true if the filename is available
-    std::cout << outPath << std::endl;
     return !std::filesystem::exists(outPath);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ void cleanExit() {
     ACCESS_LOG << "Process killed successfully." << std::endl;
 
     // Cleanup config resources
-    cleanupConfig();
+    conf::cleanupConfig();
 }
 
 /******************** WELCOME BANNER METHODS ********************/
@@ -88,7 +88,7 @@ int main() {
     initSigHandler();
 
     // Load config files
-    if (loadConfig() == CONF_FAILURE) {
+    if (conf::loadConfig() == CONF_FAILURE) {
         cleanExit();
         return 1;
     }

--- a/src/util/string_tools.cpp
+++ b/src/util/string_tools.cpp
@@ -1,25 +1,48 @@
 #include "string_tools.hpp"
 
-void splitStringUnique(std::unordered_set<std::string>& splitVec, const std::string& string, const char delimiter, const bool stripWhitespace) {
+void splitString(std::vector<std::string>& vec, const std::string& string, const char delimiter, const bool stripWhitespace) {
     size_t startIndex = 0;
-    for (size_t i = 0; i < string.size(); i++) {
+    for (size_t i = 0; i < string.size(); ++i) {
         if (string[i] == delimiter) {
             std::string substr = string.substr(startIndex, i-startIndex);
             if (stripWhitespace)
                 trimString(substr);
             if (substr.size() > 0)
-                splitVec.insert(substr);
+                vec.push_back(substr);
             startIndex = i+1;
         }
     }
 
-    // append last snippet
+    // Append last snippet
     if (startIndex < string.size()) {
         std::string substr = string.substr(startIndex);
         if (stripWhitespace)
             trimString(substr);
         if (substr.size() > 0)
-            splitVec.insert(substr);
+            vec.push_back(substr);
+    }
+}
+
+void splitStringUnique(std::unordered_set<std::string>& set, const std::string& string, const char delimiter, const bool stripWhitespace) {
+    size_t startIndex = 0;
+    for (size_t i = 0; i < string.size(); ++i) {
+        if (string[i] == delimiter) {
+            std::string substr = string.substr(startIndex, i-startIndex);
+            if (stripWhitespace)
+                trimString(substr);
+            if (substr.size() > 0)
+                set.insert(substr);
+            startIndex = i+1;
+        }
+    }
+
+    // Append last snippet
+    if (startIndex < string.size()) {
+        std::string substr = string.substr(startIndex);
+        if (stripWhitespace)
+            trimString(substr);
+        if (substr.size() > 0)
+            set.insert(substr);
     }
 }
 

--- a/src/util/string_tools.hpp
+++ b/src/util/string_tools.hpp
@@ -14,6 +14,7 @@ inline void strToUpper(std::string& str) {
     std::transform(str.begin(), str.end(), str.begin(), ::toupper);
 }
 
+void splitString(std::vector<std::string>&, const std::string&, const char, const bool);
 void splitStringUnique(std::unordered_set<std::string>&, const std::string&, const char, const bool);
 void stringReplaceAll(std::string&, const std::string&, const std::string&);
 void trimString(std::string&);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.15.1
+Mercury v0.16.0


### PR DESCRIPTION
## About
I've resolved four main issues in this release, #122, #128, #137, and #141. I've also made a few minor bug fixes as noted below.

Here is the v0.16.0 proposed changelog entry:

## v0.16.0
- Refactored & streamlined config loader script (#128)
    - Now gracefully handles invalid formatting for lines in mimes.conf
- Extended index file support to allow multiple files (#137)
    - Renamed IndexFile -> IndexFiles
    - Contains a comma-separated list of all index file names to look for, in order left to right
    - Now allows specifying no index file
- Added Access node w/ Allow & Deny nodes for restricting access (#141)
- No longer requires ShowDirectoryIndexes node in Match nodes (defaults to true)
- Fixed Match patterns applying to full file paths, not relative paths
- Fixed IPv6 client IP resolution on Windows (previously worked only for ::1)
- Added BindAddressIPv4 and BindAddressIPv6 nodes to control bind address (#122)
    - Replaced EnableIPv4 and EnableIPv6 nodes