### PR TITLE
[Feature] Range Header Support & Bug Fixes (Bump v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.17.0
+- Fixed bad URI handling for legacy HTTP versions
+- Dramatically reduced memory usage when parsing Requests
+    - Down from 4 STL string copies to 0
+
 ## v0.16.0
 - Refactored & streamlined config loader script (#128)
     - Now gracefully handles invalid formatting for lines in mimes.conf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Now partially supports Range header (#142)
     - Returns 416 Range Not Satisfiable if attempting to use multipart byte ranges but WILL still merge overlapping ranges if possible
         - May look into multipart byte range support later
+- Improved internal heap memory handling (#136)
 
 ## v0.16.0
 - Refactored & streamlined config loader script (#128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     - Returns 416 Range Not Satisfiable if attempting to use multipart byte ranges but WILL still merge overlapping ranges if possible
         - May look into multipart byte range support later
 - Improved internal heap memory handling (#136)
+- Windows PHP setup script now initializes php.ini
+    - Now properly initializes PHP's upload_tmp_dir to tmp in the Mercury root
 
 ## v0.16.0
 - Refactored & streamlined config loader script (#128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 ## v0.17.0
 - Fixed bad URI handling for legacy HTTP versions
 - Dramatically reduced memory usage when parsing Requests
-    - Down from 4 STL string copies to 0
+- Now skips Chunked Transfer Encoding for bodies smaller than the response buffer size
+- Fixed sending Content-Encoding with precompressed bodies
+    - Applies to HTTP/1.0 & sufficiently small HTTP/1.1 bodies
+- Fixed sending Content-Length with Chunked Transfer Encoding responses
+- Max response size now only applies to MemoryStreams, FileStreams are exempt (uses Chunked Transfer Encoding for large files)
+- Now partially supports Range header (#142)
+    - Returns 416 Range Not Satisfiable if attempting to use multipart byte ranges but WILL still merge overlapping ranges if possible
+        - May look into multipart byte range support later
 
 ## v0.16.0
 - Refactored & streamlined config loader script (#128)

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@
 - [Table of Contents](#table-of-contents)
 - [About](#about)
 - [Getting Started](#getting-started)
-    - [Setting Up PHP](#setting-up-php)
     - [Config Files](#config-files)
     - [Log Files](#log-files)
-- [Build Info](#build-info)
-    - [Linux & Windows Builds](#linux--windows-builds)
+    - [Setting Up PHP](#setting-up-php)
     - [TLS Certs](#tls-certs)
         - [For Linux](#for-linux)
         - [For Windows](#for-windows)
         - [For Developers](#for-developers)
+    - [Troubleshooting](#troubleshooting)
+- [Build Info](#build-info)
+    - [Linux & Windows Builds](#linux--windows-builds)
     - [Compatibility](#compatibility)
     - [Making Releases](#making-releases)
 - [Testing Suite](#testing-suite)
@@ -78,26 +79,6 @@ Windows users have the option to use their own PHP installation instead by modif
 
 **Note: By default, in "mercury.conf" PHP support is disabled. Enable PHP by changing the value of the EnablePHPCGI node to on.**
 
-## Build Info
-
-The `/build_tools/` directory contains all necessary shell scripts for building static binaries.
-
-Binaries are placed in the `/bin/` directory, `mercury` for Linux and `mercury.exe` for Windows.
-
-**Note: Mercury binaries must be run from within the `/bin/` directory as resources & config files are loaded relative to the working directory.**
-
-### Linux & Windows Builds
-
-To build for Linux and/or Windows, use the following steps:
-
-1. Install all necessary dependencies & extract static libraries.
-
-    `make libs`.
-
-2. Using GNU Make, build for your desired platform(s) via `make linux`, `make windows`, or `make all`.
-
-Note: see [Compatibility](#compatibility) section for software compatibility.
-
 ### TLS Certs
 
 Self-signed TLS 1.3 certs are now available with OpenSSL.
@@ -117,6 +98,39 @@ Update the `$OPENSSL_PATH` variable in `/conf/ssl/makecert.ps1` with your correc
 #### For Developers
 In your Linux/Debian environment, use `make cert` in the root directory of this project and enter your information to automatically create a new certificate pair.
 Your certificate will be located at `/conf/ssl/cert.pem` and your private key at `/conf/ssl/key.pem`.
+
+**Note: By default, in "mercury.conf" TLS is disabled. Enable TLS by changing the value of the TLSPort node to a port like 443.**
+
+### Troubleshooting
+
+Currently, Powershell scripts distributed on Windows distributions are blocked from running if they are downloaded from the internet.
+If you encounter issues running these scripts, run the following Powershell command to unblock these files to allow them to work.
+
+```
+Unblock-File /path/to/your/file.ps1
+```
+
+This will allow files like the TLS certificate maker (/conf/ssl/makecert.ps1) and PHP installer (/conf/setup_php.ps1) to run properly.
+
+## Build Info
+
+The `/build_tools/` directory contains all necessary shell scripts for building static binaries.
+
+Binaries are placed in the `/bin/` directory, `mercury` for Linux and `mercury.exe` for Windows.
+
+**Note: Mercury binaries must be run from within the `/bin/` directory as resources & config files are loaded relative to the working directory.**
+
+### Linux & Windows Builds
+
+To build for Linux and/or Windows, use the following steps:
+
+1. Install all necessary dependencies & extract static libraries.
+
+    `make libs`.
+
+2. Using GNU Make, build for your desired platform(s) via `make linux`, `make windows`, or `make all`.
+
+Note: see [Compatibility](#compatibility) section for software compatibility.
 
 ### Compatibility
 

--- a/conf/setup_php.ps1
+++ b/conf/setup_php.ps1
@@ -18,4 +18,12 @@ Invoke-WebRequest -Uri $DownloadUrl -OutFile $ZipFile -UseBasicParsing
 Expand-Archive -Path $ZipFile -DestinationPath "php" -Force
 Remove-Item -Path $ZipFile -Force
 
+# Copy php.ini
+Copy-Item php/php.ini-development php/php.ini
+
+# Update tmp directory
+$content = Get-Content php/php.ini -Raw
+$content = [System.Text.RegularExpressions.Regex]::Replace($content, ';upload_tmp_dir\s*=.*', 'upload_tmp_dir = ../tmp')
+Set-Content -Path php/php.ini -Value $content
+
 Pop-Location

--- a/src/http/body_stream.hpp
+++ b/src/http/body_stream.hpp
@@ -2,11 +2,14 @@
 #define __HTTP_BODY_STREAM_HPP
 
 #include <fstream>
+#include <queue>
 #include <string>
 #include <vector>
 
 #include <brotli/encode.h>
 #include <zlib.h>
+
+#include "byte_range.hpp"
 
 #define STREAM_SUCCESS 0
 #define STREAM_FAILURE 1
@@ -71,8 +74,19 @@ namespace http {
 
             // Returns true if the stream is already compressed
             virtual bool isPrecompressed() const { return false; };
+
+            // Adds a new byte range
+            void addByteRange(byte_range_t byteRange);
+
+            // Returns true if there are more byte ranges left
+            inline size_t getTotalNumByteRanges() const { return byteRanges.size(); };
+
+            // Returns the byte range at index i, but does NOT check if one exists (will fail if empty)
+            inline const byte_range_t& getByteRange(size_t i) const { return byteRanges[i]; };
         protected:
             int _status = STREAM_SUCCESS;
+            std::vector<byte_range_t> byteRanges;
+            size_t byteRangeIndex = 0;
     };
 
     class FileStream : public IBodyStream {

--- a/src/http/byte_range.hpp
+++ b/src/http/byte_range.hpp
@@ -1,0 +1,8 @@
+#ifndef __HTTP_BYTE_RANGE_HPP
+#define __HTTP_BYTE_RANGE_HPP
+
+#include <vector>
+
+typedef std::pair<size_t, size_t> byte_range_t;
+
+#endif

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -36,7 +36,7 @@ namespace http {
 
     // Fwd. decs
     void parseAcceptHeader(std::unordered_set<std::string>&, std::string&);
-    void parseRangeHeader(byte_range_t&, std::string&);
+    void parseRangeHeader(std::vector<byte_range_t>&, std::string&);
 
     Request::Request(headers_map_t& headers, const std::string& raw, std::string clientIP, const bool isHTTPS, const bool isContentTooLarge)
         : headers(headers) {
@@ -225,7 +225,7 @@ namespace http {
             splitVec.insert(mime.substr(0, mime.find(';')));
     }
 
-    void parseRangeHeader(byte_range_t& splitVec, std::string& rawHeader) {
+    void parseRangeHeader(std::vector<byte_range_t>& splitVec, std::string& rawHeader) {
         trimString(rawHeader);
         size_t unitStart = rawHeader.find("bytes");
         if (unitStart == std::string::npos) return;
@@ -265,7 +265,7 @@ namespace http {
             }
 
             // Emplace byte range
-            splitVec.emplace_back( std::pair<size_t, size_t>(startIndex, endIndex) );
+            splitVec.emplace_back( byte_range_t(startIndex, endIndex) );
         }
     }
 

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -3,6 +3,7 @@
 
 #include "../pch/common.hpp"
 
+#include "byte_range.hpp"
 #include "response.hpp"
 
 namespace http {
@@ -21,8 +22,6 @@ namespace http {
     // Used to extract headers and status info from partial request
     typedef std::unordered_map<std::string, std::string> headers_map_t;
     void loadEarlyHeaders(headers_map_t&, const std::string&);
-
-    typedef std::vector<std::pair<size_t, size_t>> byte_range_t;
 
     class Request {
         public:
@@ -57,7 +56,7 @@ namespace http {
 
             std::unordered_set<std::string> acceptedMIMETypes;
             std::unordered_set<std::string> acceptedEncodings;
-            byte_range_t byteRanges;
+            std::vector<byte_range_t> byteRanges;
 
             std::string ipStr;
             bool isHTTPS;

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -22,6 +22,8 @@ namespace http {
     typedef std::unordered_map<std::string, std::string> headers_map_t;
     void loadEarlyHeaders(headers_map_t&, const std::string&);
 
+    typedef std::vector<std::pair<size_t, size_t>> byte_range_t;
+
     class Request {
         public:
             Request(headers_map_t& headers, const std::string&, std::string, const bool, const bool);
@@ -37,13 +39,14 @@ namespace http {
             inline int getCompressMethod() const { return compressMethod; };
 
             inline const headers_map_t& getHeaders() const { return headers; };
+            inline const std::vector<std::pair<size_t, size_t>>& getByteRanges() const { return byteRanges; };
 
             bool isMIMEAccepted(const std::string&) const;
             bool isEncodingAccepted(const std::string&) const;
             inline bool usesHTTPS() const { return isHTTPS; };
             inline bool isContentTooLarge() const { return _isContentTooLarge; };
-            inline bool isURIBad() const { return hasBadURI; };
-            inline bool getHasExplicitlyDefinedHTTPVersion0_9() const { return hasExplicitlyDefinedHTTPVersion0_9; };
+            inline bool has400Error() const { return _has400Error; };
+            inline bool hasExplicitHTTP0_9() const { return _hasExplicitHTTP0_9; };
 
             bool isFileValid(Response& response, const File& file) const;
             bool isInDocumentRoot(Response&, const std::string&) const;
@@ -54,6 +57,7 @@ namespace http {
 
             std::unordered_set<std::string> acceptedMIMETypes;
             std::unordered_set<std::string> acceptedEncodings;
+            byte_range_t byteRanges;
 
             std::string ipStr;
             bool isHTTPS;
@@ -64,8 +68,8 @@ namespace http {
 
             std::string pathStr;
             std::string rawPathStr; // The path BEFORE URI decoding
-            bool hasBadURI = false; // Set to true if the decodeURI method fails, handled by Response object
-            bool hasExplicitlyDefinedHTTPVersion0_9; // Set to true if the status line has HTTP/0.9 explicitly in it (not allowed)
+            bool _hasExplicitHTTP0_9; // Set to true if the status line has HTTP/0.9 explicitly in it (not allowed)
+            bool _has400Error = false; // If true, handle as 400 Bad Request
 
             std::string httpVersionStr;
 

--- a/src/http/response.hpp
+++ b/src/http/response.hpp
@@ -13,6 +13,7 @@
 #include "../io/file.hpp"
 #include "../util/string_tools.hpp"
 #include "body_stream.hpp"
+#include "byte_range.hpp"
 
 // The minimum size for a body to be compressed
 #define MIN_COMPRESSION_SIZE 750
@@ -27,6 +28,7 @@ namespace http {
             inline uint16_t getStatus() const { return httpVersion == "HTTP/0.9" ? 0 : statusCode; };
             void setHeader(std::string name, const std::string& value);
             void clearHeader(std::string);
+            void clearHeaders() { headers.clear(); };
             void setCompressMethod(const int compressMethod);
 
             int loadBodyFromErrorDoc(const uint16_t statusCode);
@@ -40,6 +42,9 @@ namespace http {
             int getContentLength() const;
 
             ssize_t beginStreamingBody(const bool isHTMLAccepted, const bool omitBody, std::function<ssize_t(const char*, const size_t)>&);
+
+            // Returns true if the ranges are valid, false otherwise
+            bool extendByteRanges(const std::vector<byte_range_t>& byteRanges);
         private:
             bool precompressBody();
 
@@ -49,6 +54,11 @@ namespace http {
             int compressMethod = NO_COMPRESS;
 
             std::unordered_map<std::string, std::string> headers;
+
+            // For precompressed bodies
+            std::vector<byte_range_t> originalByteRanges;
+            size_t originalBodySize = 0;
+            size_t totalByteRangeSize = 0; // The total size of all the byte range data
     };
 
 };

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -397,7 +397,7 @@ namespace http {
         } else if (request.getVersion() == "HTTP/1.0" && conf::ENABLE_LEGACY_HTTP) {
             pResponse = version::handler_1_0::genResponse(request);
         } else if (request.getVersion() == "HTTP/0.9" && conf::ENABLE_LEGACY_HTTP
-            && !request.getHasExplicitlyDefinedHTTPVersion0_9()) {
+            && !request.hasExplicitHTTP0_9()) {
             pResponse = version::handler_0_9::genResponse(request);
         } else {
             pResponse = new Response("HTTP/1.1"); // Default version

--- a/src/http/server.hpp
+++ b/src/http/server.hpp
@@ -12,6 +12,7 @@
     #include <poll.h>
 #endif
 
+#include <memory>
 #include <shared_mutex>
 
 #include "../pch/common.hpp"
@@ -44,7 +45,7 @@ namespace http {
             void acceptLoop();
             void handleReqs(const int, const std::string);
             void kill();
-            Response* genResponse(Request&);
+            std::unique_ptr<Response> genResponse(Request&);
         protected:
             // Socket methods
             inline void clearBuffer(char*);

--- a/src/http/version/handler_0_9.cpp
+++ b/src/http/version/handler_0_9.cpp
@@ -17,6 +17,12 @@ namespace http::version::handler_0_9 {
             return pResponse;
         }
 
+        // Verify no 400 errors have been met
+        if ( request.has400Error() ) {
+            pResponse->loadBodyFromErrorDoc(400);
+            return pResponse;
+        }
+
         // Verify access is permitted
         if (!conf::matchConfigs.empty()) {
             // Format raw path & remove query string

--- a/src/http/version/handler_0_9.cpp
+++ b/src/http/version/handler_0_9.cpp
@@ -6,9 +6,9 @@
 
 namespace http::version::handler_0_9 {
 
-    Response* genResponse(Request& request) {
+    std::unique_ptr<Response> genResponse(Request& request) {
         // Create Response object
-        Response* pResponse = new Response("HTTP/0.9");
+        std::unique_ptr<Response> pResponse = std::unique_ptr<Response>(new Response("HTTP/0.9"));
 
         // Check if method is valid
         const METHOD method = request.getMethod();

--- a/src/http/version/handler_0_9.hpp
+++ b/src/http/version/handler_0_9.hpp
@@ -1,11 +1,13 @@
 #ifndef __HTTP_VERSION_HANDLER_0_9_HPP
 #define __HTTP_VERSION_HANDLER_0_9_HPP
 
+#include <memory>
+
 #include "../request.hpp"
 #include "../response.hpp"
 
 namespace http::version::handler_0_9 {
-    Response* genResponse(Request&);
+    std::unique_ptr<Response> genResponse(Request&);
 }
 
 #endif

--- a/src/http/version/handler_1_0.cpp
+++ b/src/http/version/handler_1_0.cpp
@@ -115,6 +115,11 @@ namespace http {
                         if (pResponse->getContentLength() > 0)
                             pResponse->setHeader("Content-Type", file.MIME);
 
+                        // Update the byte ranges
+                        if (pResponse->getContentLength() > 0)
+                            if (!pResponse->extendByteRanges(request.getByteRanges()))
+                                setStatusMaybeErrorDoc(request, *pResponse, 416); // Range Not Satisfiable
+
                         // Load additional headers for body loading
                         for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
                             if (std::regex_match(file.rawPath, pMatch->getPattern()))

--- a/src/http/version/handler_1_0.cpp
+++ b/src/http/version/handler_1_0.cpp
@@ -6,141 +6,137 @@
 
 #define ALLOWED_STATIC_METHODS "GET, HEAD"
 
-namespace http {
-    namespace version {
-        namespace handler_1_0 {
+namespace http::version::handler_1_0 {
 
-            void setStatusMaybeErrorDoc(Request& req, Response& res, const int status) {
-                res.setStatus(status);
-                if (req.isMIMEAccepted("text/html"))
-                    res.loadBodyFromErrorDoc(status);
-            }
+    void setStatusMaybeErrorDoc(Request& req, Response& res, const int status) {
+        res.setStatus(status);
+        if (req.isMIMEAccepted("text/html"))
+            res.loadBodyFromErrorDoc(status);
+    }
 
-            Response* genResponse(Request& request) {
-                // Create Response object
-                Response* pResponse = new Response("HTTP/1.0");
+    std::unique_ptr<Response> genResponse(Request& request) {
+        // Create Response object
+        std::unique_ptr<Response> pResponse = std::unique_ptr<Response>(new Response("HTTP/1.0"));
 
-                // Check if method is valid
-                const METHOD method = request.getMethod();
-                if (method != METHOD::GET && method != METHOD::HEAD && method != METHOD::POST) {
-                    setStatusMaybeErrorDoc(request, *pResponse, 501); // Not Implemented
-                    return pResponse;
-                }
+        // Check if method is valid
+        const METHOD method = request.getMethod();
+        if (method != METHOD::GET && method != METHOD::HEAD && method != METHOD::POST) {
+            setStatusMaybeErrorDoc(request, *pResponse, 501); // Not Implemented
+            return pResponse;
+        }
 
-                // Verify no 400 errors have been met
-                if ( request.has400Error() ) {
-                    setStatusMaybeErrorDoc(request, *pResponse, 400);
-                    return pResponse;
-                }
+        // Verify no 400 errors have been met
+        if ( request.has400Error() ) {
+            setStatusMaybeErrorDoc(request, *pResponse, 400);
+            return pResponse;
+        }
 
-                // Verify access is permitted
-                if (!conf::matchConfigs.empty()) {
-                    // Format raw path & remove query string
-                    std::string rawPath = request.getPathStr();
-                    const size_t queryIndex = rawPath.find('/');
-                    while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
-                        rawPath.pop_back();
+        // Verify access is permitted
+        if (!conf::matchConfigs.empty()) {
+            // Format raw path & remove query string
+            std::string rawPath = request.getPathStr();
+            const size_t queryIndex = rawPath.find('/');
+            while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
+                rawPath.pop_back();
 
-                    // Create sanitized IP address
-                    try {
-                        conf::SanitizedIP sip( conf::parseSanitizedClientIP(request.getIPStr()) );
+            // Create sanitized IP address
+            try {
+                conf::SanitizedIP sip( conf::parseSanitizedClientIP(request.getIPStr()) );
 
-                        // Check Match patterns
-                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
-                            if (std::regex_match(rawPath, pMatch->getPattern())) {
-                                // Verify access is permitted
-                                if (!pMatch->getAccessControl()->isIPAccepted(sip)) {
-                                    setStatusMaybeErrorDoc(request, *pResponse, 403);
-                                    return pResponse;
-                                }
-                            }
+                // Check Match patterns
+                for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
+                    if (std::regex_match(rawPath, pMatch->getPattern())) {
+                        // Verify access is permitted
+                        if (!pMatch->getAccessControl()->isIPAccepted(sip)) {
+                            setStatusMaybeErrorDoc(request, *pResponse, 403);
+                            return pResponse;
                         }
-                    } catch (std::invalid_argument&) {
-                        ERROR_LOG << "Invalid IP address while parsing sanitized IP" << std::endl;
-                        setStatusMaybeErrorDoc(request, *pResponse, 500);
-                        return pResponse;
                     }
                 }
-
-                // Verify the body (which is ignored in the Request object) wasn't too large
-                if (request.isContentTooLarge()) {
-                    setStatusMaybeErrorDoc(request, *pResponse, 413);
-                    return pResponse;
-                }
-
-                // Verify path is restricted to document root
-                if (!request.isInDocumentRoot(*pResponse, ALLOWED_STATIC_METHODS))
-                    return pResponse;
-
-                // Lookup file & validate it doesn't have anything wrong with it
-                File file(request.getPathStr());
-                if (!request.isFileValid(*pResponse, file))
-                    return pResponse;
-
-                // Switch on method
-                switch (request.getMethod()) {
-                    case METHOD::HEAD:
-                    case METHOD::GET: {
-                        // Check accepted MIMES
-                        if (!request.isMIMEAccepted(file.MIME)) {
-                            setStatusMaybeErrorDoc(request, *pResponse, 406);
-                            break;
-                        }
-
-                        // Check if previously cached
-                        const auto pLastModTS = request.getHeader("IF-MODIFIED-SINCE");
-                        if (pLastModTS != nullptr) {
-                            // Compare timestamps
-                            try {
-                                // serverTime <= clientTime
-                                if (getFileModTimeT(file.path) <= getTimeTFromGMT(*pLastModTS)) {
-                                    pResponse->setStatus(304);
-                                    break;
-                                }
-                            } catch (...) {
-                                // Comparison failed, re-send content as if updated
-                            }
-                        }
-
-                        // Attempt to buffer resource
-                        if (pResponse->loadBodyFromFile(file) == IO_FAILURE) {
-                            setStatusMaybeErrorDoc(request, *pResponse, 500);
-                            break;
-                        }
-
-                        // Otherwise, body loaded successfully
-                        pResponse->setStatus(200);
-
-                        // Set MIME if there is content to return
-                        if (pResponse->getContentLength() > 0)
-                            pResponse->setHeader("Content-Type", file.MIME);
-
-                        // Update the byte ranges
-                        if (pResponse->getContentLength() > 0)
-                            if (!pResponse->extendByteRanges(request.getByteRanges()))
-                                setStatusMaybeErrorDoc(request, *pResponse, 416); // Range Not Satisfiable
-
-                        // Load additional headers for body loading
-                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
-                            if (std::regex_match(file.rawPath, pMatch->getPattern()))
-                                for (auto [name, value] : pMatch->getHeaders())
-                                    pResponse->setHeader(name, value);
-                        break;
-                    }
-                    default: { // Method is allowed but invalid for static file
-                        // If the request allows HTML, return an HTML display
-                        pResponse->setHeader("Allow", ALLOWED_STATIC_METHODS);
-                        setStatusMaybeErrorDoc(request, *pResponse, 405);
-                        break;
-                    }
-                }
-
-                // Return Response ptr
+            } catch (std::invalid_argument&) {
+                ERROR_LOG << "Invalid IP address while parsing sanitized IP" << std::endl;
+                setStatusMaybeErrorDoc(request, *pResponse, 500);
                 return pResponse;
             }
-
         }
+
+        // Verify the body (which is ignored in the Request object) wasn't too large
+        if (request.isContentTooLarge()) {
+            setStatusMaybeErrorDoc(request, *pResponse, 413);
+            return pResponse;
+        }
+
+        // Verify path is restricted to document root
+        if (!request.isInDocumentRoot(*pResponse, ALLOWED_STATIC_METHODS))
+            return pResponse;
+
+        // Lookup file & validate it doesn't have anything wrong with it
+        File file(request.getPathStr());
+        if (!request.isFileValid(*pResponse, file))
+            return pResponse;
+
+        // Switch on method
+        switch (request.getMethod()) {
+            case METHOD::HEAD:
+            case METHOD::GET: {
+                // Check accepted MIMES
+                if (!request.isMIMEAccepted(file.MIME)) {
+                    setStatusMaybeErrorDoc(request, *pResponse, 406);
+                    break;
+                }
+
+                // Check if previously cached
+                const auto pLastModTS = request.getHeader("IF-MODIFIED-SINCE");
+                if (pLastModTS != nullptr) {
+                    // Compare timestamps
+                    try {
+                        // serverTime <= clientTime
+                        if (getFileModTimeT(file.path) <= getTimeTFromGMT(*pLastModTS)) {
+                            pResponse->setStatus(304);
+                            break;
+                        }
+                    } catch (...) {
+                        // Comparison failed, re-send content as if updated
+                    }
+                }
+
+                // Attempt to buffer resource
+                if (pResponse->loadBodyFromFile(file) == IO_FAILURE) {
+                    setStatusMaybeErrorDoc(request, *pResponse, 500);
+                    break;
+                }
+
+                // Otherwise, body loaded successfully
+                pResponse->setStatus(200);
+
+                // Set MIME if there is content to return
+                if (pResponse->getContentLength() > 0)
+                    pResponse->setHeader("Content-Type", file.MIME);
+
+                // Update the byte ranges
+                if (pResponse->getContentLength() > 0)
+                    if (!pResponse->extendByteRanges(request.getByteRanges()))
+                        setStatusMaybeErrorDoc(request, *pResponse, 416); // Range Not Satisfiable
+
+                // Load additional headers for body loading
+                for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
+                    if (std::regex_match(file.rawPath, pMatch->getPattern()))
+                        for (auto [name, value] : pMatch->getHeaders())
+                            pResponse->setHeader(name, value);
+                break;
+            }
+            default: { // Method is allowed but invalid for static file
+                // If the request allows HTML, return an HTML display
+                pResponse->setHeader("Allow", ALLOWED_STATIC_METHODS);
+                setStatusMaybeErrorDoc(request, *pResponse, 405);
+                break;
+            }
+        }
+
+        // Return Response ptr
+        return pResponse;
     }
+
 }
 
 #undef ALLOWED_STATIC_METHODS

--- a/src/http/version/handler_1_0.cpp
+++ b/src/http/version/handler_1_0.cpp
@@ -27,6 +27,12 @@ namespace http {
                     return pResponse;
                 }
 
+                // Verify no 400 errors have been met
+                if ( request.has400Error() ) {
+                    setStatusMaybeErrorDoc(request, *pResponse, 400);
+                    return pResponse;
+                }
+
                 // Verify access is permitted
                 if (!conf::matchConfigs.empty()) {
                     // Format raw path & remove query string

--- a/src/http/version/handler_1_0.hpp
+++ b/src/http/version/handler_1_0.hpp
@@ -1,11 +1,13 @@
 #ifndef __HTTP_VERSION_HANDLER_1_0_HPP
 #define __HTTP_VERSION_HANDLER_1_0_HPP
 
+#include <memory>
+
 #include "../request.hpp"
 #include "../response.hpp"
 
 namespace http::version::handler_1_0 {
-    Response* genResponse(Request&);
+    std::unique_ptr<Response> genResponse(Request&);
 }
 
 #endif

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -31,9 +31,9 @@ namespace http {
                     return pResponse;
                 }
 
-                // Verify Host header is present for HTTP/1.1+ (RFC 2616) & URI isn't malformed
-                if ( request.getHeader("HOST") == nullptr || request.isURIBad() ) {
-                    setStatusMaybeErrorDoc(request, *pResponse, 400);
+                // Verify no 400 errors have been met
+                if ( request.has400Error() ) {
+                    pResponse->loadBodyFromErrorDoc(400);
                     return pResponse;
                 }
 

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -8,168 +8,164 @@
 #define ALLOWED_STATIC_METHODS "GET, HEAD, OPTIONS"
 #define ALLOWED_METHODS "GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE"
 
-namespace http {
-    namespace version {
-        namespace handler_1_1 {
+namespace http::version::handler_1_1 {
 
-            void setStatusMaybeErrorDoc(Request& req, Response& res, const int status) {
-                res.setStatus(status);
-                if (req.isMIMEAccepted("text/html"))
-                    res.loadBodyFromErrorDoc(status);
-            }
+    void setStatusMaybeErrorDoc(Request& req, Response& res, const int status) {
+        res.setStatus(status);
+        if (req.isMIMEAccepted("text/html"))
+            res.loadBodyFromErrorDoc(status);
+    }
 
-            Response* genResponse(Request& request) {
-                // Create Response object
-                Response* pResponse = new Response("HTTP/1.1");
+    std::unique_ptr<Response> genResponse(Request& request) {
+        // Create Response object
+        std::unique_ptr<Response> pResponse = std::unique_ptr<Response>(new Response("HTTP/1.1"));
 
-                // Check if method is valid
-                const METHOD method = request.getMethod();
-                if (method != METHOD::GET && method != METHOD::HEAD && method != METHOD::OPTIONS
-                    && method != METHOD::POST && method != METHOD::PUT && method != METHOD::DEL
-                    && method != METHOD::PATCH) {
-                    setStatusMaybeErrorDoc(request, *pResponse, 501); // Not Implemented
-                    return pResponse;
-                }
+        // Check if method is valid
+        const METHOD method = request.getMethod();
+        if (method != METHOD::GET && method != METHOD::HEAD && method != METHOD::OPTIONS
+            && method != METHOD::POST && method != METHOD::PUT && method != METHOD::DEL
+            && method != METHOD::PATCH) {
+            setStatusMaybeErrorDoc(request, *pResponse, 501); // Not Implemented
+            return pResponse;
+        }
 
-                // Verify no 400 errors have been met
-                if ( request.has400Error() ) {
-                    pResponse->loadBodyFromErrorDoc(400);
-                    return pResponse;
-                }
+        // Verify no 400 errors have been met
+        if ( request.has400Error() ) {
+            pResponse->loadBodyFromErrorDoc(400);
+            return pResponse;
+        }
 
-                // Verify access is permitted
-                if (!conf::matchConfigs.empty()) {
-                    // Format raw path & remove query string
-                    std::string rawPath = request.getPathStr();
-                    const size_t queryIndex = rawPath.find('/');
-                    while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
-                        rawPath.pop_back();
+        // Verify access is permitted
+        if (!conf::matchConfigs.empty()) {
+            // Format raw path & remove query string
+            std::string rawPath = request.getPathStr();
+            const size_t queryIndex = rawPath.find('/');
+            while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
+                rawPath.pop_back();
 
-                    // Create sanitized IP address
-                    try {
-                        conf::SanitizedIP sip( conf::parseSanitizedClientIP(request.getIPStr()) );
+            // Create sanitized IP address
+            try {
+                conf::SanitizedIP sip( conf::parseSanitizedClientIP(request.getIPStr()) );
 
-                        // Check Match patterns
-                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
-                            if (std::regex_match(rawPath, pMatch->getPattern())) {
-                                // Verify access is permitted
-                                if (!pMatch->getAccessControl()->isIPAccepted(sip)) {
-                                    setStatusMaybeErrorDoc(request, *pResponse, 403);
-                                    return pResponse;
-                                }
-                            }
+                // Check Match patterns
+                for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs) {
+                    if (std::regex_match(rawPath, pMatch->getPattern())) {
+                        // Verify access is permitted
+                        if (!pMatch->getAccessControl()->isIPAccepted(sip)) {
+                            setStatusMaybeErrorDoc(request, *pResponse, 403);
+                            return pResponse;
                         }
-                    } catch (std::invalid_argument&) {
-                        ERROR_LOG << "Invalid IP address while parsing sanitized IP (" << request.getIPStr() << ')' << std::endl;
-                        setStatusMaybeErrorDoc(request, *pResponse, 500);
-                        return pResponse;
                     }
                 }
-
-                // Verify the body (which is ignored in the Request object) wasn't too large
-                if (request.isContentTooLarge()) {
-                    setStatusMaybeErrorDoc(request, *pResponse, 413);
-                    return pResponse;
-                }
-
-                File file(request.getPathStr());
-
-                // Bypass document root checks, file checks, and PHP for OPTIONS * (server-wide edge case)
-                if (method != METHOD::OPTIONS || request.getRawPathStr() != "*") {
-                    // Verify path is restricted to document root
-                    if (!request.isInDocumentRoot(*pResponse, ALLOWED_STATIC_METHODS))
-                        return pResponse;
-
-                    // Lookup file & validate it doesn't have anything wrong with it
-                    if (!request.isFileValid(*pResponse, file))
-                        return pResponse;
-
-                    // Check for PHP files
-                    if (conf::IS_PHP_ENABLED && file.path.ends_with(".php")) {
-                        cgi::handlePHPRequest(file, request, *pResponse);
-
-                        // Load additional headers
-                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
-                            if (std::regex_match(file.rawPath, pMatch->getPattern()))
-                                for (auto [name, value] : pMatch->getHeaders())
-                                    pResponse->setHeader(name, value);
-
-                        return pResponse;
-                    }
-                }
-
-                // Switch on method
-                switch (request.getMethod()) {
-                    case METHOD::HEAD:
-                    case METHOD::GET: {
-                        // Check accepted MIMES
-                        if (!request.isMIMEAccepted(file.MIME)) {
-                            setStatusMaybeErrorDoc(request, *pResponse, 406);
-                            break;
-                        }
-
-                        // Check if previously cached
-                        const auto pLastModTS = request.getHeader("IF-MODIFIED-SINCE");
-                        if (pLastModTS != nullptr) {
-                            // Compare timestamps
-                            try {
-                                // serverTime <= clientTime
-                                if (getFileModTimeT(file.path) <= getTimeTFromGMT(*pLastModTS)) {
-                                    pResponse->setStatus(304);
-                                    break;
-                                }
-                            } catch (...) {
-                                // Comparison failed, re-send content as if updated
-                            }
-                        }
-
-                        // Attempt to buffer resource
-                        if (pResponse->loadBodyFromFile(file) == IO_FAILURE) {
-                            setStatusMaybeErrorDoc(request, *pResponse, 500);
-                            break;
-                        }
-
-                        // Otherwise, body loaded successfully
-                        pResponse->setStatus(200);
-
-                        // Set MIME if there is content to return
-                        if (pResponse->getContentLength() > 0)
-                            pResponse->setHeader("Content-Type", file.MIME);
-
-                        // Update the byte ranges
-                        if (pResponse->getContentLength() > 0)
-                            if (!pResponse->extendByteRanges(request.getByteRanges()))
-                                setStatusMaybeErrorDoc(request, *pResponse, 416); // Range Not Satisfiable
-
-                        // Load additional headers for body loading
-                        for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
-                            if (std::regex_match(file.rawPath, pMatch->getPattern()))
-                                for (auto [name, value] : pMatch->getHeaders())
-                                    pResponse->setHeader(name, value);
-                        break;
-                    }
-                    case METHOD::OPTIONS: { // OPTIONS introduced in HTTP/1.1
-                        if (request.getRawPathStr() == "*") // Server-wide edge case
-                            pResponse->setHeader("Allow", ALLOWED_METHODS);
-                        else
-                            pResponse->setHeader("Allow", ALLOWED_STATIC_METHODS);
-                        pResponse->setStatus(204);
-                        break;
-                    }
-                    default: { // Method is allowed but invalid for static file
-                        // If the request allows HTML, return an HTML display
-                        pResponse->setHeader("Allow", ALLOWED_STATIC_METHODS);
-                        setStatusMaybeErrorDoc(request, *pResponse, 405);
-                        break;
-                    }
-                }
-
-                // Return Response ptr
+            } catch (std::invalid_argument&) {
+                ERROR_LOG << "Invalid IP address while parsing sanitized IP (" << request.getIPStr() << ')' << std::endl;
+                setStatusMaybeErrorDoc(request, *pResponse, 500);
                 return pResponse;
             }
-
         }
+
+        // Verify the body (which is ignored in the Request object) wasn't too large
+        if (request.isContentTooLarge()) {
+            setStatusMaybeErrorDoc(request, *pResponse, 413);
+            return pResponse;
+        }
+
+        File file(request.getPathStr());
+
+        // Bypass document root checks, file checks, and PHP for OPTIONS * (server-wide edge case)
+        if (method != METHOD::OPTIONS || request.getRawPathStr() != "*") {
+            // Verify path is restricted to document root
+            if (!request.isInDocumentRoot(*pResponse, ALLOWED_STATIC_METHODS))
+                return pResponse;
+
+            // Lookup file & validate it doesn't have anything wrong with it
+            if (!request.isFileValid(*pResponse, file))
+                return pResponse;
+
+            // Check for PHP files
+            if (conf::IS_PHP_ENABLED && file.path.ends_with(".php")) {
+                cgi::handlePHPRequest(file, request, *pResponse);
+
+                // Load additional headers
+                for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
+                    if (std::regex_match(file.rawPath, pMatch->getPattern()))
+                        for (auto [name, value] : pMatch->getHeaders())
+                            pResponse->setHeader(name, value);
+
+                return pResponse;
+            }
+        }
+
+        // Switch on method
+        switch (request.getMethod()) {
+            case METHOD::HEAD:
+            case METHOD::GET: {
+                // Check accepted MIMES
+                if (!request.isMIMEAccepted(file.MIME)) {
+                    setStatusMaybeErrorDoc(request, *pResponse, 406);
+                    break;
+                }
+
+                // Check if previously cached
+                const auto pLastModTS = request.getHeader("IF-MODIFIED-SINCE");
+                if (pLastModTS != nullptr) {
+                    // Compare timestamps
+                    try {
+                        // serverTime <= clientTime
+                        if (getFileModTimeT(file.path) <= getTimeTFromGMT(*pLastModTS)) {
+                            pResponse->setStatus(304);
+                            break;
+                        }
+                    } catch (...) {
+                        // Comparison failed, re-send content as if updated
+                    }
+                }
+
+                // Attempt to buffer resource
+                if (pResponse->loadBodyFromFile(file) == IO_FAILURE) {
+                    setStatusMaybeErrorDoc(request, *pResponse, 500);
+                    break;
+                }
+
+                // Otherwise, body loaded successfully
+                pResponse->setStatus(200);
+
+                // Set MIME if there is content to return
+                if (pResponse->getContentLength() > 0)
+                    pResponse->setHeader("Content-Type", file.MIME);
+
+                // Update the byte ranges
+                if (pResponse->getContentLength() > 0)
+                    if (!pResponse->extendByteRanges(request.getByteRanges()))
+                        setStatusMaybeErrorDoc(request, *pResponse, 416); // Range Not Satisfiable
+
+                // Load additional headers for body loading
+                for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
+                    if (std::regex_match(file.rawPath, pMatch->getPattern()))
+                        for (auto [name, value] : pMatch->getHeaders())
+                            pResponse->setHeader(name, value);
+                break;
+            }
+            case METHOD::OPTIONS: { // OPTIONS introduced in HTTP/1.1
+                if (request.getRawPathStr() == "*") // Server-wide edge case
+                    pResponse->setHeader("Allow", ALLOWED_METHODS);
+                else
+                    pResponse->setHeader("Allow", ALLOWED_STATIC_METHODS);
+                pResponse->setStatus(204);
+                break;
+            }
+            default: { // Method is allowed but invalid for static file
+                // If the request allows HTML, return an HTML display
+                pResponse->setHeader("Allow", ALLOWED_STATIC_METHODS);
+                setStatusMaybeErrorDoc(request, *pResponse, 405);
+                break;
+            }
+        }
+
+        // Return Response ptr
+        return pResponse;
     }
+
 }
 
 #undef ALLOWED_STATIC_METHODS

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -136,6 +136,11 @@ namespace http {
                         if (pResponse->getContentLength() > 0)
                             pResponse->setHeader("Content-Type", file.MIME);
 
+                        // Update the byte ranges
+                        if (pResponse->getContentLength() > 0)
+                            if (!pResponse->extendByteRanges(request.getByteRanges()))
+                                setStatusMaybeErrorDoc(request, *pResponse, 416); // Range Not Satisfiable
+
                         // Load additional headers for body loading
                         for (const std::unique_ptr<conf::Match>& pMatch : conf::matchConfigs)
                             if (std::regex_match(file.rawPath, pMatch->getPattern()))

--- a/src/http/version/handler_1_1.hpp
+++ b/src/http/version/handler_1_1.hpp
@@ -1,11 +1,13 @@
 #ifndef __HTTP_VERSION_HANDLER_1_1_HPP
 #define __HTTP_VERSION_HANDLER_1_1_HPP
 
+#include <memory>
+
 #include "../request.hpp"
 #include "../response.hpp"
 
 namespace http::version::handler_1_1 {
-    Response* genResponse(Request&);
+    std::unique_ptr<Response> genResponse(Request&);
 }
 
 #endif

--- a/src/util/string_tools.cpp
+++ b/src/util/string_tools.cpp
@@ -83,6 +83,22 @@ void formatHeaderCasing(std::string& header) {
     }
 }
 
+// Reads from the input string until the next line or end,
+// starting at startIndex and updating it in place (by ref).
+// Returns true if there was data read, false otherwise.
+bool readLine(const std::string& input, std::string& lineBuf, size_t& startIndex) {
+    // Check if at end
+    if (startIndex == input.length()) return false;
+
+    // Otherwise, read the next line
+    size_t endIndex = input.find('\n', startIndex);
+    lineBuf = input.substr(startIndex, endIndex - startIndex);
+
+    // Update startIndex
+    startIndex = (endIndex == std::string::npos) ? input.length() : (endIndex + 1);
+    return true;
+}
+
 bool isMostlyAscii(const std::string& data, double thresh) {
     int asciiCount = 0;
 

--- a/src/util/string_tools.hpp
+++ b/src/util/string_tools.hpp
@@ -21,6 +21,11 @@ void trimString(std::string&);
 void decodeURI(std::string&);
 void formatHeaderCasing(std::string&);
 
+// Reads from the input string until the next line or end,
+// starting at startIndex and updating it in place (by ref).
+// Returns true if there was data read, false otherwise.
+bool readLine(const std::string& input, std::string& lineBuf, size_t& startIndex);
+
 bool isMostlyAscii(const std::string&, double=0.95);
 
 #endif

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -83,20 +83,34 @@ cases = [
     TestCase(method="HEAD", path="..\\",            expected_status=400),
     TestCase(method="HEAD", path="/../",            expected_status=400),
     TestCase(method="HEAD", path="\\..\\",          expected_status=400),
-
     TestCase(method="HEAD", path="\\..\\",          expected_status=400),
     TestCase(method="HEAD", path="%2e%2e%2f",       expected_status=400),
     TestCase(method="HEAD", path="%2e%2e%5c",       expected_status=400),
     TestCase(method="HEAD", path="%2e%2e/",         expected_status=400),
     TestCase(method="HEAD", path="..%2f",           expected_status=400),
-
     TestCase(method="HEAD", path="%2e%2e\\",        expected_status=400),
     TestCase(method="HEAD", path="%252e%252e%255c", expected_status=400),
     TestCase(method="HEAD", path="..%255c",         expected_status=400),
 
+    TestCase(method="HEAD", path=".",               expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="../",             expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="..\\",            expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="/../",            expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="\\..\\",          expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="\\..\\",          expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="%2e%2e%2f",       expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="%2e%2e%5c",       expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="%2e%2e/",         expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="..%2f",           expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="%2e%2e\\",        expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="%252e%252e%255c", expected_status=400, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="..%255c",         expected_status=400, http_ver="HTTP/1.0"),
+
     # CRLF injection test cases
     TestCase(method="HEAD", path="/%0D%0A",                 expected_status=404),
     TestCase(method="HEAD", path="/index.html?q=%0D%0A",    expected_status=200),
+    TestCase(method="HEAD", path="/%0D%0A",                 expected_status=404, http_ver="HTTP/1.0"),
+    TestCase(method="HEAD", path="/index.html?q=%0D%0A",    expected_status=200, http_ver="HTTP/1.0"),
 
     # Success cases
     TestCase(method="HEAD", path="/",           expected_status=200),

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.16.0
+Mercury v0.17.0


### PR DESCRIPTION
## About
I've fixed a few bugs and added partial support for the Range header. See the attached changelog snippet for more information:
Fixes #142

## v0.17.0
- Fixed bad URI handling for legacy HTTP versions
- Dramatically reduced memory usage when parsing Requests
- Now skips Chunked Transfer Encoding for bodies smaller than the response buffer size
- Fixed sending Content-Encoding with precompressed bodies
    - Applies to HTTP/1.0 & sufficiently small HTTP/1.1 bodies
- Fixed sending Content-Length with Chunked Transfer Encoding responses
- Max response size now only applies to MemoryStreams, FileStreams are exempt (uses Chunked Transfer Encoding for large files)
- Now partially supports Range header (#142)
    - Returns 416 Range Not Satisfiable if attempting to use multipart byte ranges but WILL still merge overlapping ranges if possible
        - May look into multipart byte range support later
- Improved internal heap memory handling (#136)
- Windows PHP setup script now initializes php.ini
    - Now properly initializes PHP's upload_tmp_dir to tmp in the Mercury root