### PR TITLE
[Feature] Add Test Cases for Range Header

### DIFF
--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -146,5 +146,11 @@ cases = [
 
     # Test server-wide OPTIONS
     TestCase(method="HEAD", path="*", expected_status=400, http_ver="HTTP/1.1"),
-    TestCase(method="OPTIONS", path="*", expected_status=204, http_ver="HTTP/1.1")
+    TestCase(method="OPTIONS", path="*", expected_status=204, http_ver="HTTP/1.1"),
+
+    # Test Range header
+    TestCase(method="HEAD", path="/", expected_status=206, http_ver="HTTP/1.1", headers={"RANGE": "bytes=0-13"}),
+    TestCase(method="HEAD", path="/", expected_status=416, http_ver="HTTP/1.1", headers={"RANGE": "bytes=0-13, -19"}),
+    TestCase(method="HEAD", path="/", expected_status=206, http_ver="HTTP/1.0", headers={"RANGE": "bytes=0-13"}),
+    TestCase(method="HEAD", path="/", expected_status=416, http_ver="HTTP/1.0", headers={"RANGE": "bytes=0-13, -19"})
 ]


### PR DESCRIPTION
## About
After merging v0.17.0, I realized I never explicitly added test cases for the Range header. I've added a few for HTTP/1.0 and HTTP/1.1 in this small PR.