### PR TITLE
[Docs] Fix Stray Blue Mark After Badge Anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <div align="center">
     <img src="docs/og-image.jpg" width="300" height="158">
     <br>
-    <a href="https://opensource.org/licenses/MIT">
-        <img src="https://img.shields.io/badge/License-MIT-orange.svg">
-    </a>
+    <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-orange.svg"></a>
     <img src="https://img.shields.io/badge/Language-C%2B%2B-orange">
     <img src="https://img.shields.io/github/stars/travis-heavener/mercury?style=flat&label=Stars&color=orange">
     <br>
@@ -11,9 +9,7 @@
 </div>
 
 <div align="center">
-    <a href="https://github.com/travis-heavener/mercury/actions/workflows/build.yml">
-        <img style="margin-top: 0.5rem; margin-bottom: 0" src="https://github.com/travis-heavener/mercury/actions/workflows/build.yml/badge.svg">
-    </a>
+    <a href="https://github.com/travis-heavener/mercury/actions/workflows/build.yml"><img style="margin-top: 0.5rem; margin-bottom: 0" src="https://github.com/travis-heavener/mercury/actions/workflows/build.yml/badge.svg"></a>
     <h3><em>A lightweight, configurable HTTP server</em></h3>
     <h3>Project by Travis Heavener</h3>
 </div>


### PR DESCRIPTION
## About
Previously, the badge anchors in the main README had a stray mark after them, which I have fixed. I will rebuild v0.18.2 with this minor change.

## Screenshots
Before:
<img width="211" height="113" alt="image" src="https://github.com/user-attachments/assets/aed3eded-6ee7-44b2-9874-332db81f9ca8" />

After:
<img width="201" height="124" alt="image" src="https://github.com/user-attachments/assets/3125b400-2e61-4110-aa37-de38faa546a6" />