### PR TITLE
[Bug] Fix Windows PHP Setup Build Tool

### DIFF
--- a/build_tools/setup_win_php.sh
+++ b/build_tools/setup_win_php.sh
@@ -8,9 +8,15 @@ if [ -d "php" ]; then
 fi
 
 # Download zip archive
-DOWNLOAD_URL="https://downloads.php.net/~windows/releases/php-8.4.12-Win32-vs17-x64.zip"
+DOWNLOAD_URL="https://downloads.php.net/~windows/releases/archives/php-8.4.12-Win32-vs17-x64.zip"
 wget -q --no-check-certificate "$DOWNLOAD_URL"
 
 # Unzip the archive
 unzip -q "php-8.4.12-Win32-vs17-x64.zip" -d "php"
 rm -f "php-8.4.12-Win32-vs17-x64.zip"
+
+# Copy php.ini
+cp "php/php.ini-development" "php/php.ini"
+
+# Update tmp directory
+sed -i "s|;upload_tmp_dir\s*=.*|upload_tmp_dir = ../tmp|" "php/php.ini"


### PR DESCRIPTION
## About
After updating setup_php.ps1 to use the latest archived PHP version (8.4.12) and to make a new php.ini file, I neglected to reflect these changes in the build_tools/setup_win_php.sh file, which would crash when running.

I've since fixed these small changes.