### PR TITLE
[Feature] Add UNC Path Support, Fix PHP Gateway Failures on Linux (Draft v0.18.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Removed canonicalization of tmp directory
 - Added support for UNC paths in DocumentRoot (#186)
     - Allows Windows executable execution from within a WSL environment
+- Fixed PHP scripts returning 204 No Content instead of 502 Bad Gateway on Linux if PHP-CGI is not installed (#183)
 
 ## v0.18.2
 - Stylistic README updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.18.3
+- Removed canonicalization of tmp directory
+- Added support for UNC paths in DocumentRoot (#186)
+    - Allows Windows executable execution from within a WSL environment
+
 ## v0.18.2
 - Stylistic README updates
     - Added Support Mercury section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for UNC paths in DocumentRoot (#186)
     - Allows Windows executable execution from within a WSL environment
 - Fixed PHP scripts returning 204 No Content instead of 502 Bad Gateway on Linux if PHP-CGI is not installed (#183)
+- Improved plaintext viewing for README.md (now README.txt) in releases (#176)
 
 ## v0.18.2
 - Stylistic README updates

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## About
 
-Mercury is a lightweight, configurable HTTP server made in C++ for Windows and Linux*.
+Mercury is a lightweight, configurable HTTP server made in C++ for Windows and Linux\*.
 
 \* Most (if not all) of the supported Linux distributions are for Debian (or any other distribution using APT packages).
 Additionally, most of these distributions come with glibc, which is required to be locally installed for Mercury to run.
@@ -75,7 +75,7 @@ New versions are continuously being produced and may include crucial bug fixes o
 
 Any version of Mercury marked as a "pre-release" (versions starting with "v0.x.x") is not a finalized product.
 Therefore, bugs and security vulnerabilities are still possible.
-If you encounter any unexpected behavior, please start an Issue on [github.com/travis-heavener/mercury/issues](https://github.com/travis-heavener/mercury/issues).
+If you encounter any unexpected behavior, please start an Issue on the [Mercury GitHub repository](https://github.com/travis-heavener/mercury/issues).
 
 **Note: Mercury binaries must be run from within the `/bin/` directory as resources & config files are loaded relative to the working directory.**
 
@@ -143,7 +143,7 @@ This will allow files like the TLS certificate maker (/conf/ssl/makecert.ps1) an
 
 #### Further Troubleshooting
 
-If you encounter any other issues or unexpected behavior, please consider opening an Issue (see [Contributing](#contributing)) or contacting [Travis Heavener](https://github.com/travis-heavener).
+If you encounter any other issues or unexpected behavior, please consider opening an Issue on the [Mercury GitHub repository](https://github.com/travis-heavener/mercury/issues/new/choose) or contacting [Travis Heavener](https://github.com/travis-heavener).
 
 ## Build Info
 
@@ -227,7 +227,7 @@ See [CREDITS.md](CREDITS.md)
 
 If Mercury has helped you in any way, be sure to star it on GitHub!
 
-![GitHub Repo stars](https://img.shields.io/github/stars/travis-heavener/mercury?style=flat&label=Stars&color=orange)
+[![GitHub Repo stars](https://img.shields.io/github/stars/travis-heavener/mercury?style=flat&label=Stars&color=orange)](https://github.com/travis-heavener/mercury)
 
 And, if you are a Mercury superfan, consider supporting me directly!
 

--- a/build_tools/build_release.sh
+++ b/build_tools/build_release.sh
@@ -49,6 +49,11 @@ cp -r ../{public,licenses} "./$VERSION/"
 # Create binary folder
 mkdir "./$VERSION/bin"
 
+# ==== Update README.md to README.txt ====
+
+python3 ../build_tools/release_readme_maker.py "./$VERSION/README.md"
+mv "./$VERSION/README.md" "./$VERSION/README.txt"
+
 # ==== Linux Build ====
 
 # Copy binary

--- a/build_tools/release_readme_maker.py
+++ b/build_tools/release_readme_maker.py
@@ -1,0 +1,100 @@
+"""
+
+This file formats the README into a plaintext-compatible version for releases.
+
+"""
+
+from sys import argv
+import re
+
+def remove_until_section(body: str, header: str) -> str:
+    # Find start of section
+    start = re.search(rf"^## {header}", body, flags=re.MULTILINE)
+    if start is None: return body
+    start = start.start()
+    return body[start:]
+
+def remove_section(body: str, header: str) -> str:
+    # Find start of section
+    start = re.search(rf"^## {header}", body, flags=re.MULTILINE)
+    if start is None: return body
+    start = start.start()
+
+    # Find end of section
+    end = re.search(r"^## ", body[start+1:], flags=re.MULTILINE)
+
+    if end is not None:
+        end = end.start() + start + 1
+
+    return body[:start] + (body[end:] if end is not None else "")
+
+def markout_sections(body: str) -> str:
+    # Find start of each section
+    separator = (("=" * 100) + "\n") * 2
+    offset = 0
+    while True:
+        start = re.search(rf"^## ", body[offset:], flags=re.MULTILINE)
+        if start is None: return body
+
+        start = start.start() + offset
+        offset = start + 1 + len(separator) * 2
+
+        # Add line marking before
+        body = body[:start] \
+            + separator \
+            + body[start:body.find("\n", start)] \
+            + "\n" + separator \
+            + body[body.find("\n", start)+1:]
+
+def replace_hyperlinks(body: str) -> str:
+    # Image hyperlinks first
+    body = re.sub(r"\[\!\[.*?\]\(.*?\)\]\((.*?)\)", r"\1", body)
+
+    # Hyperlinks
+    body = re.sub(r"\[(.*?)\]\((.*?)\)", r"\1 (\2)", body)
+
+    return body
+
+def main(path: str):
+    body = ""
+
+    # Read
+    with open(path, "r") as f:
+        body = f.read()
+
+    # Replace first section
+    body = remove_until_section(body, "Table of Contents")
+
+    # Remove sections
+    body = remove_section(body, "Table of Contents")
+    body = remove_section(body, "Build Info")
+    body = remove_section(body, "Testing Suite")
+    body = remove_section(body, "Contributing")
+    body = remove_section(body, "Changelog")
+    body = remove_section(body, "Credits")
+
+    # Mark out each section for visual clarity
+    body = markout_sections(body)
+
+    # Add title & heading
+    body = "# Mercury\n" \
+        + "## A lightweight, configurable HTTP server\n" \
+        + "### Project by Travis Heavener\n\n" \
+        + body
+
+    # Replace hyperlinks
+    body = replace_hyperlinks(body)
+
+    # Misc. escapes
+    body = body.replace("\\*", "*")
+
+    # Write
+    with open(path, "w") as f:
+        f.write(body)
+
+if __name__ == "__main__":
+    if len(argv) < 2:
+        print("Invalid usage: py <script> /path/to/README")
+        exit(1)
+
+    main(argv[1])

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -438,12 +438,21 @@ namespace conf {
         try {
             var = resolveCanonicalPath(var);
 
+            #ifdef _WIN32
+                if (!var.string().empty() && isUNCPath(var) && var.string().back() == '\\') {
+                    std::string buf = var.string();
+                    buf.pop_back();
+                    buf += '/';
+                    var = buf;
+                }
+            #endif
+
             // Affix trailing slash
-            if (var.string().size() > 0 && var.string().back() != '/')
+            if (!var.string().empty() && var.string().back() != '/')
                 var = var.string() + '/';
 
             // Validate path exists and is a directory (passthru to catch block if failed)
-            if (var.string().size() == 0 || !std::filesystem::exists(var) || !std::filesystem::is_directory(var))
+            if (var.string().empty() || !std::filesystem::exists(var) || !std::filesystem::is_directory(var))
                 throw std::runtime_error("");
         } catch (...) {
             /**
@@ -470,14 +479,6 @@ namespace conf {
             }
         } catch (std::filesystem::filesystem_error&) {
             std::cerr << "Failed to create \"tmp\" directory in the Mercury root directory." << std::endl;
-            return CONF_FAILURE;
-        }
-
-        // Canonicalize the tmp path
-        try {
-            TMP_PATH = resolveCanonicalPath(tmpPathStr);
-        } catch (...) {
-            std::cerr << "Failed to canonicalize \"tmp\" directory." << std::endl;
             return CONF_FAILURE;
         }
 

--- a/src/io/file_tools.cpp
+++ b/src/io/file_tools.cpp
@@ -4,7 +4,6 @@
     #include "../winheader.hpp"
 #endif
 
-#include <iostream>
 #include <random>
 
 #include "../conf/conf.hpp"
@@ -55,7 +54,7 @@ int isSymlinked(const std::filesystem::path& path) {
         return IS_SYMLINK;
 
     // Walk from document root to path, checking for symlinks & reparse points
-    const fs::path relativeToRoot = fs::relative(absolutePath, canonicalRoot);
+    const fs::path relativeToRoot = absolutePath.lexically_relative(canonicalRoot);
     fs::path currentParts = canonicalRoot;
     for (const auto& part : relativeToRoot) {
         // Check if individual part is a symlink
@@ -114,9 +113,14 @@ std::filesystem::path resolveCanonicalPath(const std::filesystem::path& path) {
 
         // Remove \\?\ prefix if present
         std::wstring resolvedPathStr(finalPathStr);
-        const std::wstring prefix = L"\\\\?\\";
+        std::wstring prefix = L"\\\\?\\";
         if (resolvedPathStr.compare(0, prefix.length(), prefix) == 0)
             resolvedPathStr = resolvedPathStr.substr(prefix.length());
+
+        // Remove UNC prefix if present
+        prefix = L"UNC";
+        if (resolvedPathStr.compare(0, prefix.length(), prefix) == 0)
+            resolvedPathStr = L"\\" + resolvedPathStr.substr(prefix.length());
 
         return std::filesystem::path(resolvedPathStr);
     #else

--- a/src/io/file_tools.hpp
+++ b/src/io/file_tools.hpp
@@ -8,6 +8,13 @@
 #define FILE_NOT_EXIST 2
 #define INTERNAL_ERROR 3
 
+// Windows-only, checks for UNC path after canonicalization
+#ifdef _WIN32
+    inline bool isUNCPath(const std::filesystem::path& path) {
+        return path.wstring().find(L"\\\\") == 0;
+    }
+#endif
+
 bool doesFileExist(const std::string&, const bool);
 bool doesDirectoryExist(const std::string&, const bool);
 int isSymlinked(const std::filesystem::path&);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.18.2
+Mercury v0.18.3


### PR DESCRIPTION
## About
I've fixed a few issues in this bugfix: PHP scripts failing on Linux w/ 204 No Content instead of 502 Bad Gateway (#183); UNC paths not resolving for WSL/network paths in Windows (#186); and I've improved release README files for plaintext viewing (#176).

Here is the full changelog:

## v0.18.3
- Removed canonicalization of tmp directory
- Added support for UNC paths in DocumentRoot (#186)
    - Allows Windows executable execution from within a WSL environment
- Fixed PHP scripts returning 204 No Content instead of 502 Bad Gateway on Linux if PHP-CGI is not installed (#183)
- Improved plaintext viewing for README.md (now README.txt) in releases (#176)