### PR TITLE
[Repo] Remove Main Pushes Triggering Extra Build & Test Workflow Run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,6 @@ name: Build & Test
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-    branches: ["main"]
-    paths:
-      - "src/**"
-      - "lib/**"
   pull_request:
     branches: ["main"]
     paths:


### PR DESCRIPTION
## About
Currently, pushes to main that modify the src or lib directories trigger an extra workflow run for Build & Test. This is redundant as any PRs that include these changes already run the workflow and if a new release is to be made, that workflow runs the Build & Test *again*.