### PR TITLE
[Bug] Fixed Document Root Parsing, UNC Paths, and Temp Files (Draft v0.18.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed directory index listings returning last modified GMT timestamps (#201)
 - Fixed document root `.` not running in Mercury root (#200)
 - Fixed temp files being created in the bin directory (#202)
+- Migrate Contributing section to CONTRIBUTING.md (#197)
 
 ## v0.18.3
 - Removed canonicalization of tmp directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.18.4
 - Fixed directory index lookups on UNC paths (#201)
 - Fixed directory index listings returning last modified GMT timestamps (#201)
+- Fixed document root `.` not running in Mercury root (#200)
 
 ## v0.18.3
 - Removed canonicalization of tmp directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.18.4
+- Fixed directory index lookups on UNC paths (#201)
+- Fixed directory index listings returning last modified GMT timestamps (#201)
+
 ## v0.18.3
 - Removed canonicalization of tmp directory
 - Added support for UNC paths in DocumentRoot (#186)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed directory index lookups on UNC paths (#201)
 - Fixed directory index listings returning last modified GMT timestamps (#201)
 - Fixed document root `.` not running in Mercury root (#200)
+- Fixed temp files being created in the bin directory (#202)
 
 ## v0.18.3
 - Removed canonicalization of tmp directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+Contributions to the Mercury project are always welcome and appreciated.
+
+## Issues & Pull Requests
+There are two available Issue templates on the Mercury GitHub repository: one for bug reports and one for feature requests.
+If you'd like to go rogue and make your own Issue without a template that is allowed, but please stick to the available templates unless you know what you're doing.
+Please make use of available labels for issues and pull requests, they are there for a reason.
+
+## Branch Cleanup
+When closing a pull request, it is encouraged that you delete your branch from the remote (GitHub). While this isn't a hard *requirement*, it is strongly encouraged as it improves the clarity of what branches are open or not.
+
+Committing directly to main is disabled, so you must create a pull request for every change you'd like to make to main.
+
+## Reviewing Pull Requests
+In general, pull requests must pass all tests that are applicable. For example, a PR that changes documentation will likely have no GitHub Actions available for it, but one that changes something in the source code will be subject to build tests and cross-platform test cases. Each PR should ideally be reviewed by a third-party, unless approved by [@travis-heavener](https://github.com/travis-heavener). Like issues, the proper labels should be applied.

--- a/README.md
+++ b/README.md
@@ -195,20 +195,7 @@ The test runner is available in the `tests` directory.
 With Python installed, fire up the Mercury server, cd into the tests directory, and use the `run.py` file to run a number of tests against the server.
 
 ## Contributing
-Contributions to the Mercury project are always welcome and appreciated.
-
-### Issues & Pull Requests
-There are two available Issue templates on the Mercury GitHub repository: one for bug reports and one for feature requests.
-If you'd like to go rogue and make your own Issue without a template that is allowed, but please stick to the available templates unless you know what you're doing.
-Please make use of available labels for issues and pull requests, they are there for a reason.
-
-### Branch Cleanup
-When closing a pull request, it is encouraged that you delete your branch from the remote (GitHub). While this isn't a hard *requirement*, it is strongly encouraged as it improves the clarity of what branches are open or not.
-
-Committing directly to main is disabled, so you must create a pull request for every change you'd like to make to main.
-
-### Reviewing Pull Requests
-In general, pull requests must pass all tests that are applicable. For example, a PR that changes documentation will likely have no GitHub Actions available for it, but one that changes something in the source code will be subject to build tests and cross-platform test cases. Each PR should ideally be reviewed by a third-party, unless approved by [@travis-heavener](https://github.com/travis-heavener). Like issues, the proper labels should be applied.
+See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Changelog
 See [CHANGELOG.md](CHANGELOG.md)

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -485,6 +485,9 @@ namespace conf {
             return CONF_FAILURE;
         }
 
+        // Set the temp path
+        TMP_PATH = tmpPathStr;
+
         return CONF_SUCCESS;
     }
 }

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -408,7 +408,10 @@ namespace conf {
         }
 
         // Format string
-        if (value.find("./") == 0) { // Use relative path
+        if (value == ".") { // Use relative path
+            var = CWD;
+            if (isLogFile) return CONF_FAILURE; // Cannot be a directory
+        } else if (value.find("./") == 0) { // Use relative path
             var = CWD / value.substr(2);
             if (isLogFile) createLogDirectoryIfMissing(var);
         } else { // Try as absolute path

--- a/src/http/response.cpp
+++ b/src/http/response.cpp
@@ -71,7 +71,7 @@ namespace http {
         const int bodyStatus = file.loadToBuffer(pBodyStream);
 
         // Get last modified GMT string
-        if (bodyStatus == IO_SUCCESS)
+        if (bodyStatus == IO_SUCCESS && !file.isDirectory)
             this->setHeader("Last-Modified", file.getLastModifiedGMT());
 
         this->setHeader("Content-Length", std::to_string(this->pBodyStream->size()));

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -11,9 +11,7 @@ File::File(const std::string& rawPath) {
     // Update the actual path
     if ((rawPath.size() == 1 || rawPath[1] == '?') && rawPath[0] == '/') {
         this->path = conf::DOCUMENT_ROOT.string();
-
-        // Replace any backslashes w/ fwd slashes
-        std::replace( this->path.begin(), this->path.end(), '\\', '/' );
+        normalizeBackslashes( path ); // Replace any backslashes w/ fwd slashes
     } else {
         try {
             this->path = resolveCanonicalPath( // Canonicalize
@@ -28,7 +26,7 @@ File::File(const std::string& rawPath) {
         }
 
         // Replace any backslashes w/ fwd slashes
-        std::replace( this->path.begin(), this->path.end(), '\\', '/' );
+        normalizeBackslashes(path);
 
         // Re-append slash if directory
         if (doesDirectoryExist(this->path, true)) this->path += '/';
@@ -44,8 +42,8 @@ File::File(const std::string& rawPath) {
     // Check for index file
     if (this->path.back() == '/') {
         for (const std::string& indexFile : conf::INDEX_FILES) {
-            if (std::filesystem::exists(this->path + indexFile) &&
-                !std::filesystem::is_directory(this->path + indexFile)) {
+            if (std::filesystem::exists(path + indexFile) &&
+                !std::filesystem::is_directory(path + indexFile)) {
                 this->path += indexFile;
                 break;
             }

--- a/src/io/file_tools.hpp
+++ b/src/io/file_tools.hpp
@@ -9,11 +9,17 @@
 #define INTERNAL_ERROR 3
 
 // Windows-only, checks for UNC path after canonicalization
-#ifdef _WIN32
-    inline bool isUNCPath(const std::filesystem::path& path) {
+// On Linux, returns false always
+inline bool isUNCPath(const std::filesystem::path& path) {
+    #ifdef _WIN32
         return path.wstring().find(L"\\\\") == 0;
-    }
-#endif
+    #else
+        (void)path;
+        return false;
+    #endif
+}
+
+void normalizeBackslashes(std::string& path);
 
 bool doesFileExist(const std::string&, const bool);
 bool doesDirectoryExist(const std::string&, const bool);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.18.3
+Mercury v0.18.4


### PR DESCRIPTION
## About
I've fixed a number of bugs in this release (#200, #201, #202) as well as minor README updates (#197).

Previously, the temp file directory was not being properly initialized, which has since been fixed (#202). I've also addressed and fixed UNC path lookups breaking when normalizing the `\\` to `//` and when trying to fetch a GMT timestamp for directories (#201). As for the document root fixes, using `.` now properly resolves to the Mercury project root instead of the program's CWD in the bin directory (#200).

I've also moved the Contributing section in README.md to CONTRIBUTING.md to make it appear more appropriately in the repository on GitHub.

Here is the full changelog:

## v0.18.4
- Fixed directory index lookups on UNC paths (#201)
- Fixed directory index listings returning last modified GMT timestamps (#201)
- Fixed document root `.` not running in Mercury root (#200)
- Fixed temp files being created in the bin directory (#202)
- Migrate Contributing section to CONTRIBUTING.md (#197)