### PR TITLE
[Bug] Fix WinPHPCGIPath Checking if EnablePHPCGI is Off (Draft v0.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.20.1
+- Fix Windows port checking if WinPHPCGIPath exists even if EnablePHPCGI is set to off (#217)
+
 ## v0.20.0
 - Migrate PugiXML to build_tools install with all other libs (#212)
 - Add Zstandard (Zstd) compression (#159)

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -184,7 +184,7 @@ namespace conf {
             return CONF_FAILURE;
 
         #ifdef _WIN32
-            if (loadPath(root, PHP_CGI_EXE_PATH, "WinPHPCGIPath") == CONF_FAILURE)
+            if (IS_PHP_ENABLED && loadPath(root, PHP_CGI_EXE_PATH, "WinPHPCGIPath") == CONF_FAILURE)
                 return CONF_FAILURE;
         #endif
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.20.0
+Mercury v0.20.1


### PR DESCRIPTION
## About
I've fixed issue #217 where Mercury would check if the default WinPHPCGIPath was valid even if EnablePHPCGI was off (Windows only).

Full changelog:
## v0.20.1
- Fix Windows port checking if WinPHPCGIPath exists even if EnablePHPCGI is set to off (#217)