### PR TITLE
[Feature] Support Running Mercury Outside `bin`, Add "Exit" to Exit, Improve CLI (Draft v0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.21.0
+- Add support for running Mercury outside the `bin` directory (#215)
+    - Working across UNC paths for Windows as well
+
 ## v0.20.1
 - Fix Windows port checking if WinPHPCGIPath exists even if EnablePHPCGI is set to off (#217)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
     - Working across UNC paths for Windows as well
 - Added support for typing "exit" to exit (#221)
     - Greatly improve thread closure handling
-
+- Now checks the individual version pattern (vX.X.X) when comparing against remote latest version (#195)
+- Stylistically improved welcome banner :)
 
 ## v0.20.1
 - Fix Windows port checking if WinPHPCGIPath exists even if EnablePHPCGI is set to off (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v0.21.0
 - Add support for running Mercury outside the `bin` directory (#215)
     - Working across UNC paths for Windows as well
+- Added support for typing "exit" to exit (#221)
+    - Greatly improve thread closure handling
+
 
 ## v0.20.1
 - Fix Windows port checking if WinPHPCGIPath exists even if EnablePHPCGI is set to off (#217)

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Any version of Mercury marked as a "pre-release" (versions starting with "v0.x.x
 Therefore, bugs and security vulnerabilities are still possible.
 If you encounter any unexpected behavior, please start an Issue on the [Mercury GitHub repository](https://github.com/travis-heavener/mercury/issues).
 
-**Note: Mercury binaries must be run from within the `/bin/` directory as resources & config files are loaded relative to the working directory.**
-
 ### Config Files
 
 In the `conf` directory are two config files: "mercury.conf" for server config and "mimes.conf" for a list of supported MIME types.
@@ -147,8 +145,6 @@ If you encounter any other issues or unexpected behavior, please consider openin
 The `/build_tools/` directory contains all necessary shell scripts for building static binaries.
 
 Binaries are placed in the `/bin/` directory, `mercury` for Linux and `mercury.exe` for Windows.
-
-**Note: Mercury binaries must be run from within the `/bin/` directory as resources & config files are loaded relative to the working directory.**
 
 ### Linux & Windows
 

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -302,6 +302,31 @@ namespace conf {
         std::filesystem::current_path( previousCWD );
     }
 
+    void getMajorMinorPatchFromVersion(std::string ver, int& major, int& minor, int& patch) {
+        ver = ver.substr(9); // Remove "Mercury v"
+
+        const size_t firstDot = ver.find('.');
+        const size_t secondDot = ver.find('.', firstDot+1);
+
+        major = std::stoi( ver.substr(0, firstDot) );
+        minor = std::stoi( ver.substr(firstDot+1, secondDot - firstDot) );
+        patch = std::stoi( ver.substr(secondDot+1) );
+    }
+
+    // Compares the current version to the latest on the remote
+    bool isVersionOutdated(const std::string& latestRemoteVersion) {
+        int remoteMajor, remoteMinor, remotePatch;
+        getMajorMinorPatchFromVersion(latestRemoteVersion, remoteMajor, remoteMinor, remotePatch);
+
+        int thisMajor, thisMinor, thisPatch;
+        getMajorMinorPatchFromVersion(conf::VERSION, thisMajor, thisMinor, thisPatch);
+
+        // Compare versions
+        return thisMajor < remoteMajor ||
+            (thisMajor == remoteMajor  && thisMinor < remoteMinor) ||
+            (thisMajor == remoteMajor  && thisMinor == remoteMinor && thisPatch < remotePatch);
+    }
+
     /************************* Config loader helpers *************************/
 
     int loadUint(const pugi::xml_node& root, unsigned int& var, const std::string& nodeName, const bool allowZero) {

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -9,9 +9,9 @@
 #define CONF_SUCCESS 0
 #define CONF_FAILURE 1
 
-#define CONF_FILE "../conf/mercury.conf"
-#define MIMES_FILE "../conf/mimes.conf"
-#define VERSION_FILE "../version.txt"
+#define CONF_FILE "conf/mercury.conf"
+#define MIMES_FILE "conf/mimes.conf"
+#define VERSION_FILE "version.txt"
 
 typedef unsigned short port_t;
 
@@ -61,7 +61,7 @@ namespace conf {
 
     // Static methods
     int loadConfig();
-    inline void cleanupConfig() { matchConfigs.clear(); }
+    void cleanupConfig();
 }
 
 #endif

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -62,6 +62,7 @@ namespace conf {
     // Static methods
     int loadConfig();
     void cleanupConfig();
+    bool isVersionOutdated(const std::string& latestRemoteVersion);
 }
 
 #endif

--- a/src/http/server.hpp
+++ b/src/http/server.hpp
@@ -12,6 +12,7 @@
     #include <poll.h>
 #endif
 
+#include <atomic>
 #include <memory>
 #include <shared_mutex>
 
@@ -78,6 +79,9 @@ namespace http {
             // OpenSSL
             bool useTLS;
             SSL_CTX* pSSL_CTX = nullptr;
+
+            // Used to gracefully close acceptLoop threads
+            std::atomic<bool> isExiting{false};
     };
 
     // For logs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ void cleanExit() {
 
 void awaitExitCin() {
     // Otherwise, read from cin
+    std::cout << "> ";
     std::string buf;
     std::getline(std::cin, buf);
     trimString(buf); strToUpper(buf);
@@ -66,15 +67,47 @@ void printCenteredVersion() {
     const int leftPadding = (34 - conf::VERSION.length()) / 2;
     const int rightPadding = 34 - conf::VERSION.length() - leftPadding;
 
-    std::cout << '|' << std::string(leftPadding, ' ') << conf::VERSION << std::string(rightPadding, ' ') << '|' << '\n';
+    #ifdef _WIN32
+        std::wcout << L'\u00B3';
+        std::cout << std::string(leftPadding, ' ') << conf::VERSION << std::string(rightPadding, ' ');
+        std::wcout << L'\u00B3';
+        std::cout << std::endl;
+    #else
+        std::cout << "\u2502" << std::string(leftPadding, ' ') << conf::VERSION << std::string(rightPadding, ' ') << "\u2502" << std::endl;
+    #endif
 }
 
 void printWelcomeBanner() {
-    std::cout << "------------------------------------" << std::endl;
-    printCenteredVersion();
-    std::cout << "|           ...........            |" << std::endl <<
-                 "|         \"Exit\" to close.         |" << std::endl <<
-                 "------------------------------------" << std::endl;
+    /**
+     * Prints the following message:
+     * 
+     * ┌──────────────────────────────────┐
+     * │          Mercury vX.X.X          │
+     * │           ════════════           │
+     * │         "Exit" to close.         │
+     * └──────────────────────────────────┘
+     */
+    #ifdef _WIN32
+        std::wcout << L'\u00DA';
+        for (int i = 0; i < 34; ++i) std::wcout << L'\u00C4';
+        std::wcout << L'\u00BF' << std::endl;
+        printCenteredVersion();
+        std::wcout << L"\u00B3           \u00CD\u00CD\u00CD\u00CD\u00CD\u00CD\u00CD\u00CD\u00CD\u00CD\u00CD\u00CD           \u00B3\n"
+                      L"\u00B3         \"Exit\" to close.         \u00B3\n"
+                      L"\u00C0";
+        for (int i = 0; i < 34; ++i) std::wcout << L'\u00C4';
+        std::wcout << L'\u00D9' << std::endl;
+    #else
+        std::cout << "\u250C";
+        for (int i = 0; i < 34; ++i) std::cout << "\u2500";
+        std::cout << "\u2510" << std::endl;
+        printCenteredVersion();
+        std::cout << "\u2502           \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550           \u2502\n"
+                      "\u2502         \"Exit\" to close.         \u2502\n"
+                      "\u2514";
+        for (int i = 0; i < 34; ++i) std::cout << "\u2500";
+        std::cout << "\u2518" << std::endl;
+    #endif
     ACCESS_LOG << conf::VERSION << " started successfully." << std::endl;
 }
 
@@ -82,7 +115,7 @@ void printWelcomeBanner() {
 
 int main() {
     // Initialize Winsock API
-    #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+    #ifdef _WIN32
         WSADATA wsa;
         if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
             std::cerr << "Failed to initialize Winsock API.\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,11 +70,11 @@ void printCenteredVersion() {
 }
 
 void printWelcomeBanner() {
-    std::cout << "------------------------------------\n";
+    std::cout << "------------------------------------" << std::endl;
     printCenteredVersion();
-    std::cout << "|           ...........            |\n"
-                 "|         \"Exit\" to close.         |\n"
-                 "------------------------------------\n";
+    std::cout << "|           ...........            |" << std::endl <<
+                 "|         \"Exit\" to close.         |" << std::endl <<
+                 "------------------------------------" << std::endl;
     ACCESS_LOG << conf::VERSION << " started successfully." << std::endl;
 }
 
@@ -102,8 +102,12 @@ int main() {
     // Check for new version at startup
     if (conf::CHECK_LATEST_RELEASE) {
         const std::string latestVersion = fetchLatestVersion();
-        if (latestVersion.length() > 0 && latestVersion != conf::VERSION)
-            std::cout << "Update available! (" << latestVersion.substr(8) << ")\nSee https://wowtravis.com/mercury" << std::endl;
+        try {
+            if (latestVersion.length() > 0 && conf::isVersionOutdated(latestVersion))
+                std::cout << "Update available! (" << latestVersion.substr(8) << ")\nSee https://wowtravis.com/mercury" << std::endl;
+        } catch (std::invalid_argument&) {
+            std::cout << "Failed to compare local and remote versions!" << std::endl;
+        }
     }
 
     // Init server

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.20.1
+Mercury v0.21.0


### PR DESCRIPTION
## About
Initially, I had planned to tackle #211 and #195 in v0.21.0, but I've added a good amount of features thus far and I think it's time to publish this draft for v0.21.0.

I've resolved #215 for allowing Mercury to run outside of the `bin` directory and added "exit" to exit functionality in the console. I've also greatly improved thread closure handling and the accept loop (now calls select to check for clients before calling blocking accept). Per the start of #195, I've made sure the version checker now properly resolves if the client has a newer version than the remote latest (ie. in-dev copies).

And the icing on the cake: I've stylized the welcome banner and overall CLI feel (see Screenshots)

## Screenshots
Old:
<img width="274" height="156" alt="image" src="https://github.com/user-attachments/assets/a3a1391d-f68c-40d8-9866-df77373e9caf" />

Proposed:
<img width="265" height="155" alt="image" src="https://github.com/user-attachments/assets/29fe2f7e-3cd0-4360-8911-92aaf25a4e2d" />

## v0.21.0
- Add support for running Mercury outside the `bin` directory (#215)
    - Working across UNC paths for Windows as well
- Added support for typing "exit" to exit (#221)
    - Greatly improve thread closure handling
- Now checks the individual version pattern (vX.X.X) when comparing against remote latest version (#195)
- Stylistically improved welcome banner :)