### PR TITLE
[Misc.] Remove Unneeded PHP Setup (from v0.14.0)

### DIFF
--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Make Executable Shell Scripts
         run: chmod +x ./build_tools/*.sh
 
-      # Setup PHP for Windows
-      - name: Setup PHP for Windows
-        run: make win_php
-
       # Run release builder
       - name: Make Release
         run: |


### PR DESCRIPTION
## About
The release maker script in v0.14.0 was given the additional task of downloading and setting up PHP as it was bundled with Windows distributions only for v0.14.0. Since v0.15.0, this has been unnecessary and has taken a slight bit of compute time for making releases via workflow.

This PR removes the unnecessary workflow step.