### PR TITLE
[Repo] Improve Build Workflow Time by Caching APT Packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,15 @@ jobs:
       - name: Install APT Deps
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: build-essential mingw-w64 nasm zlib1g-dev php-cgi
+          packages: build-essential nasm zlib1g-dev php-cgi
           version: 1.0
 
       # Install deps & build static binaries
       - name: Build Libs
         run: |
+          # Run w/o make (not installed yet)
+          sudo ./build_tools/install_workflow_deps.sh
+
           if [ ! -d libs ] || [ -z "$(ls -A libs)" ]; then
             make lib_brotli
             make lib_openssl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Deps & Build Libs
         run: |
           # Run w/o make (not installed yet)
-          sudo ./build_tools/install_deps.sh
+          sudo ./build_tools/install_workflow_deps.sh
           if [ ! -d libs ] || [ -z "$(ls -A libs)" ]; then
             make lib_brotli
             make lib_openssl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,15 @@ jobs:
       - name: Make Executable Shell Scripts
         run: sudo chmod +x ./build_tools/*.sh
 
+      # Install & cache APT deps
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: build-essential mingw-w64 nasm zlib1g-dev php-cgi
+          version: 1.0
+
       # Install deps & build static binaries
       - name: Install Deps & Build Libs
         run: |
-          # Run w/o make (not installed yet)
-          sudo ./build_tools/install_workflow_deps.sh
           if [ ! -d libs ] || [ -z "$(ls -A libs)" ]; then
             make lib_brotli
             make lib_openssl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,14 @@ jobs:
         run: sudo chmod +x ./build_tools/*.sh
 
       # Install & cache APT deps
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Install APT Deps
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: build-essential mingw-w64 nasm zlib1g-dev php-cgi
           version: 1.0
 
       # Install deps & build static binaries
-      - name: Install Deps & Build Libs
+      - name: Build Libs
         run: |
           if [ ! -d libs ] || [ -z "$(ls -A libs)" ]; then
             make lib_brotli

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Copy Default Config
         run: cp ./conf/default/*.conf ./conf
 
+      # Install & cache APT deps
       - name: Install PHP-CGI
-        run: |
-          sudo apt update
-          sudo apt install php-cgi
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: php-cgi
+          version: 1.0
 
       - name: Configure Ports & Enable IPv6/TLS
         run: |

--- a/build_tools/install_workflow_deps.sh
+++ b/build_tools/install_workflow_deps.sh
@@ -3,10 +3,7 @@
 # Installs *all* deps needed to rebuild Mercury
 sudo apt update
 sudo DEBIAN_FRONTEND=noninteractive apt install \
-    build-essential \
-    mingw-w64 nasm \
-    zlib1g-dev \
-    php-cgi \
+    mingw-w64 \
     -y --no-install-recommends
 
 echo "✅ Successfully installed workflow dependencies."

--- a/build_tools/install_workflow_deps.sh
+++ b/build_tools/install_workflow_deps.sh
@@ -2,10 +2,11 @@
 
 # Installs *all* deps needed to rebuild Mercury
 sudo apt update
-sudo apt install \
+sudo DEBIAN_FRONTEND=noninteractive apt install \
     build-essential \
     mingw-w64 nasm \
     zlib1g-dev \
-    php-cgi -y
+    php-cgi \
+    -y --no-install-recommends
 
 echo "✅ Successfully installed workflow dependencies."

--- a/build_tools/install_workflow_deps.sh
+++ b/build_tools/install_workflow_deps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Installs *all* deps needed to rebuild Mercury
+sudo apt update
+sudo apt install \
+    build-essential \
+    mingw-w64 nasm \
+    zlib1g-dev \
+    php-cgi -y
+
+echo "✅ Successfully installed workflow dependencies."


### PR DESCRIPTION
## About
I've reduced the amount of time taken by the Build & Test Workflow by about a minute by caching all the APT packages I could except for mingw-w64 (which means I have to manually install it each time which is a real PITA, it adds 2min alone).