### PR TITLE
[Feature] Add Redirect Support, Fix Match Nodes & URI Decoding (Draft v0.23.0)

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,7 +20,9 @@ jobs:
           path: ./bin
 
       - name: Copy Default Config
-        run: cp ./conf/default/*.conf ./conf
+        run: |
+          cp conf/default/mimes.conf conf/mimes.conf
+          cp tests/mercury.conf.sample conf/mercury.conf
 
       # Install & cache APT deps
       - name: Install PHP-CGI
@@ -35,10 +37,8 @@ jobs:
           sslPort=8082
 
           # Update conf/mercury.conf
-          sed -i "s|<DocumentRoot>[[:space:]]*.*[[:space:]]*</DocumentRoot>|<DocumentRoot> ./tests/files/ </DocumentRoot>|" conf/mercury.conf
           sed -i "s|<Port>[[:space:]]*[0-9]\+[[:space:]]*</Port>|<Port> $port </Port>|" conf/mercury.conf
           sed -i "s|<TLSPort>[[:space:]]*.*[[:space:]]*</TLSPort>|<TLSPort> $sslPort </TLSPort>|" conf/mercury.conf
-          sed -i "s|<EnablePHPCGI>[[:space:]]*off[[:space:]]*</EnablePHPCGI>|<EnablePHPCGI> on </EnablePHPCGI>|" conf/mercury.conf
 
           # Update tests/run.py
           sed -i "s|port[[:space:]]*=[[:space:]]*.*|port = $port|" tests/run.py

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,7 +20,9 @@ jobs:
           path: ./bin
 
       - name: Copy Default Config
-        run: Copy-Item ./conf/default/*.conf ./conf
+        run: |
+          Copy-Item ./conf/default/mimes.conf ./conf/mimes.conf
+          Copy-Item ./tests/mercury.conf.sample ./conf/mercury.conf
 
       - name: Setup PHP
         run: ./conf/setup_php.ps1
@@ -33,10 +35,8 @@ jobs:
           $filePath = "conf/mercury.conf"
           $content = Get-Content $filePath -Raw
 
-          $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<DocumentRoot>\s*.+?\s*</DocumentRoot>', "<DocumentRoot> ./tests/files/ </DocumentRoot>")
           $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<Port>\s*\d+\s*</Port>', "<Port> $port </Port>")
           $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<TLSPort>\s*.+?\s*</TLSPort>', "<TLSPort> $sslPort </TLSPort>")
-          $content = [System.Text.RegularExpressions.Regex]::Replace($content, '<EnablePHPCGI>\s*off\s*</EnablePHPCGI>', '<EnablePHPCGI> on </EnablePHPCGI>')
 
           Set-Content -Path $filePath -Value $content
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Justified CLI table in README (#240)
 - Updated Performance section in README to include what version was tested
 - Add config controls for keep-alive connections & minimum response body size for compression (#237)
+- Add Redirect node in config file (#170)
+    - See example attached in /conf/default/mercury.conf
+- Fixed Match node pattern lookups (previously was comparing empty strings)
+- Fixed Match nodes requiring Access nodes within them
+    - Was dereferencing a nullptr :(
 
 ## v0.22.2
 - Removed update.ps1 and update.sh update scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.23.0
 - Justified CLI table in README (#240)
 - Updated Performance section in README to include what version was tested
+- Add config controls for keep-alive connections & minimum response body size for compression (#237)
 
 ## v0.22.2
 - Removed update.ps1 and update.sh update scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed Match node pattern lookups (previously was comparing empty strings)
 - Fixed Match nodes requiring Access nodes within them
     - Was dereferencing a nullptr :(
+- Access logs now include the raw incoming path instead of the parsed path
 
 ## v0.22.2
 - Removed update.ps1 and update.sh update scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed Match nodes requiring Access nodes within them
     - Was dereferencing a nullptr :(
 - Access logs now include the raw incoming path instead of the parsed path
+- Fixed URI-encoded question marks breaking query string parsing in Match (and the new Redirect) nodes (#246)
 
 ## v0.22.2
 - Removed update.ps1 and update.sh update scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.23.0
+- Justified CLI table in README (#240)
+- Updated Performance section in README to include what version was tested
+
 ## v0.22.2
 - Removed update.ps1 and update.sh update scripts
     - Introduced a number of problems and disk I/O risks

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ With Python installed, fire up the Mercury server, cd into the tests directory, 
 
 Note that in mercury.conf, the DocumentRoot should point to `./tests/files/` as the testing suite has its own set of documents to run tests against.
 
+See `./tests/files/mercury.conf.sample` for a sample config file to use for the testing script.
+
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Mercury is a lighter-weight alternative to popular HTTP servers like Apache:
 | Avg. Idle Memory | **16320 KB** | 30026 KB | **Mercury is 46% lighter!** |
 | Avg. Load Memory | **20331 KB** | 32658 KB | **Mercury is 38% lighter!** |
 
-*Note: tests were conducted over IPv4 & IPv6 connections w/ and w/o SSL.
+*Note: tests were conducted over IPv4 & IPv6 connections w/ and w/o SSL (using Mercury v0.22.2).
 Each value is the average of five separate trials using the Python test cases in the Mercury repository under `tests`.*
 
 *Actual performance will vary between systems; this data is a baseline.*
@@ -152,12 +152,12 @@ Your certificate will be located at `/conf/ssl/cert.pem` and your private key at
 
 As of Mercury v0.22.0, a basic CLI is available to the user. Here is a list of available commands:
 
-| Command | Description |
-|-----|-----|
-| exit | Exit Mercury |
-| help | List available commands |
-| info | View current utilization |
-| ping | ??? |
+| Command | Description              |
+|---------|--------------------------|
+| exit    | Exit Mercury             |
+| help    | List available commands  |
+| info    | View current utilization |
+| ping    | ???                      |
 
 ### Troubleshooting
 

--- a/conf/default/mercury.conf
+++ b/conf/default/mercury.conf
@@ -1,166 +1,142 @@
 <Mercury>
-    #
     # Specifies where files are served from, relative to the Mercury directory
     #   Default: ./public/
-    #
     <DocumentRoot> ./public/ </DocumentRoot>
 
-    #
     # Controls the socket bind addresses for IPv4 and IPv6, or "off" if disabled
     #   IPv4 Default: 0.0.0.0
     #   IPv6 Default: ::
-    #
     <BindAddressIPv4> 0.0.0.0 </BindAddressIPv4>
     <BindAddressIPv6> :: </BindAddressIPv6>
 
-    #
     # Specifies what port will be used to serve cleartext (non-HTTPS) content
     #   Default: 80
-    #
     <Port> 80 </Port>
 
-    #
     # Specifies which port to serve SSL/TLS traffic over, or "off" if disabled
     # See ./conf/ssl/cert.pem and ./conf/ssl/key.pem
     #   Default: off
-    #
     <TLSPort> off </TLSPort>
 
-    #
     # Enables or disables legacy HTTP versions (HTTP/0.9, HTTP/1.0)
     #   Default: on
-    #
     <EnableLegacyHTTPVersions> on </EnableLegacyHTTPVersions>
 
-    #
     # Specifies what name for index files will be served when accessing a directory by name
     # The order (left to right) specifies which files will be searched for first, or empty if desired
     #   Default: index.html, index.htm, index.php
-    #
     <IndexFiles> index.html, index.htm, index.php </IndexFiles>
 
-    #
     # Specifies where server access & error logs are stored
     #   Access Default: ./logs/access.log
     #   Error Default: ./logs/error.log
-    #
     <AccessLogFile> ./logs/access.log </AccessLogFile>
     <ErrorLogFile> ./logs/error.log </ErrorLogFile>
 
-    #
     # Controls whether IP addresses in log files are anonymized or not.
     #   Default: false
-    #
     <RedactLogIPs> false </RedactLogIPs>
 
-    #
     # Whether or not to pass through requests for PHP files to a PHP-CGI process.
     # If disabled, the value of the WinPHPCGIPath node is ignored.
     #   Default: off
-    #
     <EnablePHPCGI> off </EnablePHPCGI>
 
-    #
     # NOTE: This node applies to Windows only
     # Points to the php-cgi.exe executable to handle PHP requests on.
     #   Default: ./php/php-cgi.exe
-    #
     <WinPHPCGIPath> ./php/php-cgi.exe </WinPHPCGIPath>
 
-    #
     # Match allows individual file/directory control over resource access via regex matches.
     # Note that the pattern matches the relative path received in the HTTP request, not an absolute path.
-    #
     <Match pattern=".*">
-        #
         # Allows HTTP response headers to be set, only valid within a Match
-        #
         <Header name="Cache-Control"> public, must-revalidate, max-age=300 </Header>
 
-        #
         # Enables or disables directory index listings, only valid within a Match (either "on" or "off").
         # Only the first ShowDirectoryIndexes node will be recognized.
         #   Default: on
-        #
         <ShowDirectoryIndexes> on </ShowDirectoryIndexes>
 
-        #
         # Controls access to content, only valid within a Match
         # The "mode" attribute controls the default policy, either to deny all except for hosts in the
         #   Allow nodes or to allow all except for hosts in the Deny nodes.
         # Note that if the mode is set to "deny all" then any Deny nodes are skipped, and vice versa
         #   for "allow all" and Allow nodes.
         #   Valid modes: "deny all" | "allow all"
-        #
         <Access mode="deny all">
             <Allow> 127.0.0.1 </Allow>
             <Allow> ::1 </Allow>
         </Access>
     </Match>
 
-    #
+    # Controls whether or not to honor keep-alive headers in requests to maintain
+    # a connection that later requests can come through
+    #   Default: on
+    <KeepAlive> on </KeepAlive>
+
+    # Specifies how long a keep-alive connection will wait for subsequent requests
+    # in SECONDS, if keep-alive connections are enabled
+    #   Default: 3
+    <KeepAliveMaxTimeout> 3 </KeepAliveMaxTimeout>
+
+    # Specifies how many requests are allowed per keep-alive connection,
+    # if keep-alive connections are enabled
+    #   Default: 100
+    <KeepAliveMaxRequests> 100 </KeepAliveMaxRequests>
+
     # Specifies how many queued requests the server can handle simultaneously
     #   Default: 100
-    #
     <MaxRequestBacklog> 100 </MaxRequestBacklog>
 
-    #
     # Specifies how large the read buffer is for requests, in bytes
     #   Default: 16384
-    #
     <RequestBufferSize> 16384 </RequestBufferSize>
 
-    #
     # Specifies how large the write buffer is for responses, in bytes
     #   Default: 16384
-    #
     <ResponseBufferSize> 16384 </ResponseBufferSize>
 
-    #
     # Specifies how large an incoming request's body is allowed to be, in bytes
     # If you experience 413 Content Too Large statuses being returned, you can increase this value
     # but beware that increasing this value too large may slow down your machine and/or cause issues
     #   Default: 268435456
-    #
     <MaxRequestBody> 268435456 </MaxRequestBody>
 
-    #
     # Specifies how large an outgoing response's body is allowed to be, in bytes
     # If you experience 413 Content Too Large statuses being returned, you can increase this value
     # but beware that increasing this value too large may slow down your machine and/or cause issues
     #   Default: 268435456
-    #
     <MaxResponseBody> 268435456 </MaxResponseBody>
 
-    #
+    # How small a response body must be to bypass using any compression methods (in bytes)
+    # This avoids the overhead and bloat of using compression algorithms on really
+    # small bodies, however values that are too large (ie. > 1000 bytes) will increase
+    # network overhead
+    #   Default: 750
+    <MinResponseCompressionSize> 750 </MinResponseCompressionSize>
+
     # Specifies how many connection threads exist for each server thread.
     # Note that under heavy load, up to MaxBurstThreadsPerChild threads may be created per
     # server thread--this value is purely the default "idle" amount of threads available.
     # There are four server threads: IPv4, IPv4 w/ TLS, IPv6, IPv6 w/ TLS
     #   Default: 12
-    #
     <IdleThreadsPerChild> 12 </IdleThreadsPerChild>
 
-    #
     # Specifies the maximum number of connection threads exist for each server thread under load.
     # Note that under normal circumstances, only the amount of IdleThreadsPerChild threads will
     # be used--up to MaxBurstThreadsPerChild threads will be utilized to decrease the overall size of
     # the connection backlog on each server thread to improve client performance.
     # There are four server threads: IPv4, IPv4 w/ TLS, IPv6, IPv6 w/ TLS
     #   Default: 60
-    #
     <MaxThreadsPerChild> 60 </MaxThreadsPerChild>
 
-    #
     # Whether or not to print the welcome banner on startup (true/false)
     #   Default: true
-    #
     <ShowWelcomeBanner> true </ShowWelcomeBanner>
 
-    #
     # Whether or not to check for a new version on startup (true/false)
     # Disabling this often will improve startup speed, but it is recommended to leave this on unless you know what you're doing.
     #   Default: true
-    #
     <StartupCheckLatestRelease> true </StartupCheckLatestRelease>
 </Mercury>

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -11,6 +11,8 @@
 #include "../io/file_tools.hpp"
 #include "../util/string_tools.hpp"
 
+#define LOAD_UINT_FORBID_ZERO false
+
 /****** EXTERNAL FIELDS ******/
 
 namespace conf {
@@ -25,6 +27,11 @@ namespace conf {
     std::optional<SanitizedIP> BIND_ADDR_IPV4;
     bool IS_IPV6_ENABLED;
     std::optional<SanitizedIP> BIND_ADDR_IPV6;
+
+    bool IS_KEEP_ALIVE_ENABLED;
+    unsigned int KEEP_ALIVE_TIMEOUT;
+    unsigned int MAX_KEEP_ALIVE_REQUESTS;
+    unsigned int MIN_COMPRESSION_SIZE;
 
     bool ENABLE_LEGACY_HTTP;
     unsigned short MAX_REQUEST_BACKLOG;
@@ -152,6 +159,9 @@ namespace conf {
         if (loadOnOff(root, IS_PHP_ENABLED, "EnablePHPCGI") == CONF_FAILURE)
             return CONF_FAILURE;
 
+        if (loadOnOff(root, IS_KEEP_ALIVE_ENABLED, "KeepAlive") == CONF_FAILURE)
+            return CONF_FAILURE;
+
         if (loadBool(root, REDACT_LOG_IPS, "RedactLogIPs") == CONF_FAILURE)
             return CONF_FAILURE;
 
@@ -184,16 +194,16 @@ namespace conf {
 
         /************ LOAD UINTS/USHORTS ************/
 
-        if (loadUint(root, PORT, "Port", false) == CONF_FAILURE)
+        if (loadUint(root, PORT, "Port", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
             return CONF_FAILURE;
 
-        if (loadUint(root, MAX_REQUEST_BACKLOG, "MaxRequestBacklog", false) == CONF_FAILURE)
+        if (loadUint(root, MAX_REQUEST_BACKLOG, "MaxRequestBacklog", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
             return CONF_FAILURE;
 
-        if (loadUint(root, REQUEST_BUFFER_SIZE, "RequestBufferSize", false) == CONF_FAILURE)
+        if (loadUint(root, REQUEST_BUFFER_SIZE, "RequestBufferSize", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
             return CONF_FAILURE;
 
-        if (loadUint(root, RESPONSE_BUFFER_SIZE, "ResponseBufferSize", false) == CONF_FAILURE)
+        if (loadUint(root, RESPONSE_BUFFER_SIZE, "ResponseBufferSize", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
             return CONF_FAILURE;
 
         if (loadUint(root, MAX_REQUEST_BODY, "MaxRequestBody") == CONF_FAILURE)
@@ -202,16 +212,25 @@ namespace conf {
         if (loadUint(root, MAX_RESPONSE_BODY, "MaxResponseBody") == CONF_FAILURE)
             return CONF_FAILURE;
 
-        if (loadUint(root, IDLE_THREADS_PER_CHILD, "IdleThreadsPerChild", false) == CONF_FAILURE)
+        if (loadUint(root, IDLE_THREADS_PER_CHILD, "IdleThreadsPerChild", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
             return CONF_FAILURE;
 
-        if (loadUint(root, MAX_THREADS_PER_CHILD, "MaxThreadsPerChild", false) == CONF_FAILURE)
+        if (loadUint(root, MAX_THREADS_PER_CHILD, "MaxThreadsPerChild", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
             return CONF_FAILURE;
 
         if (MAX_THREADS_PER_CHILD <= IDLE_THREADS_PER_CHILD) {
             std::cerr << "Failed to parse config file, MaxThreadsPerChild must be greater than IdleThreadsPerChild.";
             return CONF_FAILURE;
         }
+
+        if (loadUint(root, KEEP_ALIVE_TIMEOUT, "KeepAliveMaxTimeout", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
+            return CONF_FAILURE;
+
+        if (loadUint(root, MAX_KEEP_ALIVE_REQUESTS, "KeepAliveMaxRequests", LOAD_UINT_FORBID_ZERO) == CONF_FAILURE)
+            return CONF_FAILURE;
+
+        if (loadUint(root, MIN_COMPRESSION_SIZE, "MinResponseCompressionSize") == CONF_FAILURE)
+            return CONF_FAILURE;
 
         /************************** LOAD PATHS **************************/
 
@@ -567,3 +586,5 @@ namespace conf {
         return CONF_SUCCESS;
     }
 }
+
+#undef LOAD_UINT_FORBID_ZERO

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -40,6 +40,7 @@ namespace conf {
     unsigned int IDLE_THREADS_PER_CHILD, MAX_THREADS_PER_CHILD;
     std::vector<std::unique_ptr<Match>> matchConfigs;
     std::vector<std::string> INDEX_FILES;
+    std::vector<std::unique_ptr<Redirect>> redirectRules;
 
     std::filesystem::path ACCESS_LOG_FILE;
     std::filesystem::path ERROR_LOG_FILE;
@@ -245,7 +246,7 @@ namespace conf {
                 return CONF_FAILURE;
         #endif
 
-        /************ LOAD MATCHES & MIMES ************/
+        /************ LOAD MATCHES, REDIRECTS, & MIMES ************/
 
         pugi::xml_object_range matchNodes = root.children("Match");
         for (pugi::xml_node& match : matchNodes) {
@@ -253,6 +254,14 @@ namespace conf {
             std::unique_ptr<Match> pMatch = loadMatch(match);
             if (pMatch == nullptr) return CONF_FAILURE;
             matchConfigs.push_back( std::move(pMatch) );
+        }
+
+        pugi::xml_object_range redirectRuleNodes = root.children("Redirect");
+        for (pugi::xml_node& redirectRule : redirectRuleNodes) {
+            // Parse match
+            std::unique_ptr<Redirect> pRedirect = loadRedirect(redirectRule);
+            if (pRedirect == nullptr) return CONF_FAILURE;
+            redirectRules.push_back( std::move(pRedirect) );
         }
 
         if (loadMIMES() == CONF_FAILURE)

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -30,6 +30,11 @@ namespace conf {
     extern bool IS_IPV6_ENABLED;
     extern std::optional<SanitizedIP> BIND_ADDR_IPV6;
 
+    extern bool IS_KEEP_ALIVE_ENABLED;
+    extern unsigned int KEEP_ALIVE_TIMEOUT;
+    extern unsigned int MAX_KEEP_ALIVE_REQUESTS;
+    extern unsigned int MIN_COMPRESSION_SIZE;
+
     extern bool ENABLE_LEGACY_HTTP;
     extern unsigned short MAX_REQUEST_BACKLOG;
     extern unsigned int REQUEST_BUFFER_SIZE, RESPONSE_BUFFER_SIZE;

--- a/src/conf/conf.hpp
+++ b/src/conf/conf.hpp
@@ -5,6 +5,7 @@
 
 #include "../pch/common.hpp"
 #include "conf_match.hpp"
+#include "conf_redirect.hpp"
 
 #define CONF_SUCCESS 0
 #define CONF_FAILURE 1
@@ -42,6 +43,7 @@ namespace conf {
     extern unsigned int IDLE_THREADS_PER_CHILD, MAX_THREADS_PER_CHILD;
     extern std::vector<std::unique_ptr<Match>> matchConfigs;
     extern std::vector<std::string> INDEX_FILES;
+    extern std::vector<std::unique_ptr<Redirect>> redirectRules;
 
     extern std::filesystem::path ACCESS_LOG_FILE;
     extern std::filesystem::path ERROR_LOG_FILE;

--- a/src/conf/conf_match.cpp
+++ b/src/conf/conf_match.cpp
@@ -101,8 +101,8 @@ namespace conf {
             // Add pAccess to Match
             pMatch->setAccessControl(std::move(pAccess));
         } else {
-            // Not present, set to nullptr
-            pMatch->setAccessControl(nullptr);
+            // Not present, set to a blank Access node that allows all
+            pMatch->setAccessControl( std::unique_ptr<Access>(new Access("allow all")) );
         }
 
         // Return Match ptr

--- a/src/conf/conf_match.cpp
+++ b/src/conf/conf_match.cpp
@@ -14,7 +14,7 @@ namespace conf {
         // Extract regex
         pugi::xml_attribute patternAttr = root.attribute("pattern");
         if (!patternAttr) {
-            std::cerr << "Failed to parse config file, Match node missing pattern attribute.\n";
+            std::cerr << "Failed to parse config file, Match node missing \"pattern\" attribute." << std::endl;
             return nullptr;
         }
 
@@ -23,7 +23,7 @@ namespace conf {
         try {
             pMatch = std::make_unique<Match>( patternAttr.as_string() );
         } catch (std::regex_error&) {
-            std::cerr << "Failed to parse config file, bad Match pattern.\n";
+            std::cerr << "Failed to parse config file, bad Match pattern." << std::endl;
             return nullptr;
         }
 
@@ -35,7 +35,7 @@ namespace conf {
             // Parse header node
             pugi::xml_attribute nameAttr = headerNode.attribute("name");
             if (!nameAttr) {
-                std::cerr << "Failed to parse config file, Header node missing name attribute.\n";
+                std::cerr << "Failed to parse config file, Header node missing name attribute." << std::endl;
                 return nullptr;
             }
 
@@ -56,7 +56,7 @@ namespace conf {
 
             // Verify valid value provided
             if (showDirectoryIndexStr != "on" && showDirectoryIndexStr != "off") {
-                std::cerr << "Failed to parse config file, invalid value for ShowDirectoryIndexes node in Match.\n";
+                std::cerr << "Failed to parse config file, invalid value for ShowDirectoryIndexes node in Match." << std::endl;
                 return nullptr;
             }
 
@@ -73,13 +73,13 @@ namespace conf {
             // Extract mode
             pugi::xml_attribute modeAttr = accessNode.attribute("mode");
             if (!modeAttr) {
-                std::cerr << "Failed to parse config file, Access node missing name attribute.\n";
+                std::cerr << "Failed to parse config file, Access node missing name attribute." << std::endl;
                 return nullptr;
             }
 
             const std::string modeStr( modeAttr.as_string() );
             if (modeStr != "deny all" && modeStr != "allow all") {
-                std::cerr << "Failed to parse config file, Access node has invalid mode, must be either \"deny all\" or \"allow all\".\n";
+                std::cerr << "Failed to parse config file, Access node has invalid mode, must be either \"deny all\" or \"allow all\"." << std::endl;
                 return nullptr;
             }
 
@@ -93,7 +93,7 @@ namespace conf {
                 try {
                     pAccess->insertIP( parseSanitizedIP(childNode) );
                 } catch (std::invalid_argument&) {
-                    std::cerr << "Failed to parse config file, " << subnodeName << " node has an invalid IP address.\n";
+                    std::cerr << "Failed to parse config file, " << subnodeName << " node has an invalid IP address." << std::endl;
                     return nullptr;
                 }
             }

--- a/src/conf/conf_redirect.cpp
+++ b/src/conf/conf_redirect.cpp
@@ -1,0 +1,67 @@
+#include "conf_redirect.hpp"
+
+#include <iostream>
+
+#include "../util/string_tools.hpp"
+
+namespace conf {
+
+    Redirect::Redirect(const std::string& pattern, const std::string& to, const unsigned int status) {
+        this->pattern = std::regex(pattern);
+        this->to = to;
+        this->status = status;
+    }
+
+    void Redirect::loadRedirectedPath(const std::string& currentPath, std::string& outPath) const {
+        outPath.clear();
+
+        // Check if the regex matches
+        std::smatch matches;
+        if (!std::regex_search(currentPath, matches, pattern)) return;
+
+        // Replace matches in the "to" path
+        outPath = to;
+
+        // Count down in case there are $11 and $1
+        for (size_t i = matches.size(); i > 0; --i)
+            stringReplaceAll(outPath, "$" + std::to_string(i-1), matches[i-1].str());
+    }
+
+    std::unique_ptr<Redirect> loadRedirect(pugi::xml_node& root) {
+        // Extract regex
+        pugi::xml_attribute patternAttr = root.attribute("pattern");
+        if (!patternAttr) {
+            std::cerr << "Failed to parse config file, Redirect node missing \"pattern\" attribute." << std::endl;
+            return nullptr;
+        }
+
+        pugi::xml_attribute toAttr = root.attribute("to");
+        if (!patternAttr) {
+            std::cerr << "Failed to parse config file, Redirect node missing \"to\" attribute." << std::endl;
+            return nullptr;
+        }
+
+        unsigned int status;
+        try {
+            status = std::stoul( root.text().as_string() );
+            if (status < 300 || (status > 304 && status != 307 && status != 308))
+                throw std::invalid_argument("");
+        } catch (std::invalid_argument&) {
+            std::cerr << "Failed to parse config file, Redirect node has invalid HTTP status code." << std::endl;
+            return nullptr;
+        }
+
+        // Create new Match
+        std::unique_ptr<Redirect> pRedirect;
+        try {
+            pRedirect = std::make_unique<Redirect>( patternAttr.as_string(), toAttr.as_string(), status );
+        } catch (std::regex_error&) {
+            std::cerr << "Failed to parse config file, bad Redirect pattern." << std::endl;
+            return nullptr;
+        }
+
+        // Base case, return new ptr
+        return pRedirect;
+    }
+
+}

--- a/src/conf/conf_redirect.hpp
+++ b/src/conf/conf_redirect.hpp
@@ -1,0 +1,31 @@
+#ifndef __CONF_REDIRECT_HPP
+#define __CONF_REDIRECT_HPP
+
+#include <memory>
+#include <regex>
+
+#include <pugixml.hpp>
+
+#include "../pch/common.hpp"
+
+namespace conf {
+
+    class Redirect {
+        public:
+            Redirect(const std::string& pattern, const std::string& to, const unsigned int status);
+            inline const std::regex& getPattern() const { return pattern; }
+            inline unsigned int getStatus() const { return status; }
+
+            // Loads the redirected path to outPath if present, otherwise sets the path to the empty string
+            void loadRedirectedPath(const std::string& currentPath, std::string& outPath) const;
+        private:
+            std::regex pattern;
+            std::string to;
+            unsigned int status;
+    };
+
+    std::unique_ptr<Redirect> loadRedirect(pugi::xml_node&);
+
+}
+
+#endif

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -136,7 +136,7 @@ namespace http {
     // This method exists to combine common methods from the version handlers
     bool Request::isInDocumentRoot(Response& response, const std::string& allowedMethods) const {
         // Decode URI after removing query string
-        std::string querylessPath = rawPathStr.substr(0, rawPathStr.find("?"));
+        std::string querylessPath = rawPathStr.substr(0, rawPathStr.find('?'));
         decodeURI(querylessPath); // Doesn't need try-catch, already checked in Request constructor
 
         // Prevent lookups to files outside of the document root

--- a/src/http/response.cpp
+++ b/src/http/response.cpp
@@ -252,7 +252,7 @@ namespace http {
         // Check if the body needs to be pre-compressed (HTTP/1.0 or HTTP/1.1+ w/ small bodies)
         bool wasBodyPrecompressed = false;
         if (originalByteRanges.size() <= 1 && ((httpVersion == "HTTP/1.0" && pBodyStream->size() > 0) ||
-            (pBodyStream->size() <= conf::RESPONSE_BUFFER_SIZE && pBodyStream->size() > MIN_COMPRESSION_SIZE))) {
+            (pBodyStream->size() <= conf::RESPONSE_BUFFER_SIZE && pBodyStream->size() > conf::MIN_COMPRESSION_SIZE))) {
             if (!this->precompressBody()) { // Failed to compress body
                 // Send uncompresesed error page
                 this->originalByteRanges.clear();
@@ -282,11 +282,11 @@ namespace http {
 
         // Create a streamable, buffered compressor
         std::unique_ptr<ICompressor> pCompressor(
-            (wasBodyPrecompressed || pBodyStream->size() <= MIN_COMPRESSION_SIZE) ? nullptr : createCompressorStream(this->compressMethod)
+            (wasBodyPrecompressed || pBodyStream->size() <= conf::MIN_COMPRESSION_SIZE) ? nullptr : createCompressorStream(this->compressMethod)
         );
 
         // Skip compression for small bodies
-        if (!wasBodyPrecompressed && pBodyStream->size() <= MIN_COMPRESSION_SIZE)
+        if (!wasBodyPrecompressed && pBodyStream->size() <= conf::MIN_COMPRESSION_SIZE)
             this->clearHeader("Content-Encoding");
 
         // Update transfer encoding

--- a/src/http/response.hpp
+++ b/src/http/response.hpp
@@ -14,9 +14,6 @@
 #include "body_stream.hpp"
 #include "http_tools.hpp"
 
-// The minimum size for a body to be compressed
-#define MIN_COMPRESSION_SIZE 750
-
 namespace http {
 
     class Response {

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -378,7 +378,7 @@ namespace http {
                 // Log request
                 ACCESS_LOG << request.getMethodStr() << ' '
                         << (conf::REDACT_LOG_IPS ? "<Anonymous IP>" : request.getIPStr()) << ' '
-                        << request.getPathStr()
+                        << request.getRawPathStr()
                         << " -- (" << pResponse->getStatus() << ") ["
                         << request.getVersion() << ']'
                         << std::endl; // Flush w/ endl vs newline

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -13,9 +13,6 @@
 
 #define SOCKET_DRAIN_BUFFER_SIZE 8192
 
-#define KEEP_ALIVE_TIMEOUT_MS 3000
-#define KEEP_ALIVE_MAX_REQ 100
-
 namespace http {
 
     Server::Server(const port_t port, const bool useTLS) : port(port),
@@ -263,7 +260,7 @@ namespace http {
 
         // Track keep-alive requests for a given connection
         bool isContentTooLarge = false;
-        int keepAliveReqsLeft = KEEP_ALIVE_MAX_REQ;
+        int keepAliveReqsLeft = static_cast<int>( conf::MAX_KEEP_ALIVE_REQUESTS );
         while (keepAliveReqsLeft > 0 && !isContentTooLarge) {
             // Read buffer until headers have loaded
             thread_local std::string requestStr;
@@ -275,7 +272,7 @@ namespace http {
             while (requestStr.find("\r\n\r\n") == std::string::npos &&
                 !isForceClosed && isDataReady) {
                 struct pollfd pfd; pfd.fd = client;
-                const ssize_t pollStatus = this->waitForClientData(pfd, KEEP_ALIVE_TIMEOUT_MS);
+                const ssize_t pollStatus = this->waitForClientData(pfd, conf::KEEP_ALIVE_TIMEOUT * 1000);
                 if (pollStatus <= 0 || (pfd.revents & (POLLHUP | POLLERR))) {
                     isForceClosed = true; break; // Fatal error or timeout
                 }
@@ -320,7 +317,7 @@ namespace http {
             // Read remaining body
             while (contentLength > 0 && !isForceClosed && isDataReady) {
                 struct pollfd pfd; pfd.fd = client;
-                const ssize_t pollStatus = this->waitForClientData(pfd, KEEP_ALIVE_TIMEOUT_MS);
+                const ssize_t pollStatus = this->waitForClientData(pfd, conf::KEEP_ALIVE_TIMEOUT * 1000);
                 if (pollStatus <= 0 || (pfd.revents & (POLLHUP | POLLERR))) {
                     isForceClosed = true; break; // Fatal error or timeout
                 }
@@ -356,13 +353,13 @@ namespace http {
                 const std::string* pConnHeader = request.getHeader("Connection");
                 std::string connHeader = (pConnHeader != nullptr) ? *pConnHeader : ""; // Copy string
                 strToUpper(connHeader); // Format copied string
-                if (!isContentTooLarge &&
+                if (conf::IS_KEEP_ALIVE_ENABLED && !isContentTooLarge &&
                     (connHeader == "KEEP-ALIVE" || (connHeader == "" && request.getVersion() == "HTTP/1.1"))) {
                     // HTTP/1.1 defaults to keep-alive
                     pResponse->setHeader("Connection", "keep-alive");
                     pResponse->setHeader("Keep-Alive",
-                                "timeout=" + std::to_string(KEEP_ALIVE_TIMEOUT_MS/1000) +
-                                ", max=" + std::to_string(KEEP_ALIVE_MAX_REQ));
+                                "timeout=" + std::to_string(conf::KEEP_ALIVE_TIMEOUT) +
+                                ", max=" + std::to_string(conf::MAX_KEEP_ALIVE_REQUESTS));
                     --keepAliveReqsLeft;
                 } else { // Close connection
                     pResponse->setHeader("Connection", "close");

--- a/src/http/version/handler_0_9.cpp
+++ b/src/http/version/handler_0_9.cpp
@@ -27,7 +27,7 @@ namespace http::version::handler_0_9 {
         if (!conf::matchConfigs.empty()) {
             // Format raw path & remove query string
             std::string rawPath = request.getPathStr();
-            const size_t queryIndex = rawPath.find('/');
+            const size_t queryIndex = rawPath.find('?');
             while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
                 rawPath.pop_back();
 

--- a/src/http/version/handler_0_9.cpp
+++ b/src/http/version/handler_0_9.cpp
@@ -57,7 +57,7 @@ namespace http::version::handler_0_9 {
             return pResponse;
 
         // Lookup file & validate it doesn't have anything wrong with it
-        File file(request.getPathStr());
+        File file(request.getRawPathStr());
         if (!request.isFileValid(*pResponse, file))
             return pResponse;
 

--- a/src/http/version/handler_1_0.cpp
+++ b/src/http/version/handler_1_0.cpp
@@ -35,7 +35,7 @@ namespace http::version::handler_1_0 {
         if (!conf::matchConfigs.empty()) {
             // Format raw path & remove query string
             std::string rawPath = request.getPathStr();
-            const size_t queryIndex = rawPath.find('/');
+            const size_t queryIndex = rawPath.find('?');
             while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
                 rawPath.pop_back();
 
@@ -64,6 +64,30 @@ namespace http::version::handler_1_0 {
         if (request.isContentTooLarge()) {
             setStatusMaybeErrorDoc(request, *pResponse, 413);
             return pResponse;
+        }
+
+        // Handle redirects
+        if (!conf::redirectRules.empty()) {
+            // Format raw path & break off query string
+            std::string rawPath = request.getPathStr();
+            const size_t queryIndex = rawPath.find('?');
+            const std::string queryString = queryIndex != std::string::npos ? rawPath.substr(queryIndex) : "";
+            while (queryIndex != std::string::npos && rawPath.size() > queryIndex)
+                rawPath.pop_back();
+
+            // Check redirect rule patterns
+            std::string locationBuf;
+            for (const std::unique_ptr<conf::Redirect>& pRedirect : conf::redirectRules) {
+                pRedirect->loadRedirectedPath(rawPath, locationBuf);
+                if (locationBuf.empty()) continue;
+
+                // New location found, set status (only 300-302 available for HTTP/1.0)
+                const unsigned int status = pRedirect->getStatus();
+                if (status > 302) ERROR_LOG << "HTTP/1.0 falling back from " << status << " status to 302 status" << std::endl;
+                pResponse->setStatus( status > 302 ? 302 : status );
+                pResponse->setHeader( "Location", locationBuf );
+                return pResponse;
+            }
         }
 
         // Verify path is restricted to document root

--- a/src/http/version/handler_1_0.cpp
+++ b/src/http/version/handler_1_0.cpp
@@ -95,7 +95,7 @@ namespace http::version::handler_1_0 {
             return pResponse;
 
         // Lookup file & validate it doesn't have anything wrong with it
-        File file(request.getPathStr());
+        File file(request.getRawPathStr());
         if (!request.isFileValid(*pResponse, file))
             return pResponse;
 

--- a/src/http/version/handler_1_1.cpp
+++ b/src/http/version/handler_1_1.cpp
@@ -92,7 +92,7 @@ namespace http::version::handler_1_1 {
             }
         }
 
-        File file(request.getPathStr());
+        File file(request.getRawPathStr());
 
         // Bypass document root checks, file checks, and PHP for OPTIONS * (server-wide edge case)
         if (method != METHOD::OPTIONS || request.getRawPathStr() != "*") {

--- a/src/io/file.hpp
+++ b/src/io/file.hpp
@@ -22,7 +22,7 @@ class File {
         // The FULL, absolute path to the file
         std::string path;
 
-        // The RAW path from the HTTP request
+        // The RAW path from the HTTP request (URI decoded)
         std::string rawPath;
 
         // The query string

--- a/tests/files/?/query_string.php
+++ b/tests/files/?/query_string.php
@@ -1,0 +1,3 @@
+<?php
+
+echo $_SERVER["QUERY_STRING"];

--- a/tests/files/?/query_string.php
+++ b/tests/files/?/query_string.php
@@ -1,3 +1,0 @@
-<?php
-
-echo $_SERVER["QUERY_STRING"];

--- a/tests/files/redirect_from/foo.txt
+++ b/tests/files/redirect_from/foo.txt
@@ -1,0 +1,1 @@
+redirect_from/foo.txt

--- a/tests/files/redirect_to/bar.txt
+++ b/tests/files/redirect_to/bar.txt
@@ -1,0 +1,1 @@
+redirect_to/bar.txt

--- a/tests/files/redirect_to/foo.txt
+++ b/tests/files/redirect_to/foo.txt
@@ -1,0 +1,1 @@
+redirect_to/foo.txt

--- a/tests/mercury.conf.sample
+++ b/tests/mercury.conf.sample
@@ -1,7 +1,7 @@
 <Mercury>
     # Specifies where files are served from, relative to the Mercury directory
     #   Default: ./public/
-    <DocumentRoot> ./public/ </DocumentRoot>
+    <DocumentRoot> ./tests/files/ </DocumentRoot>
 
     # Controls the socket bind addresses for IPv4 and IPv6, or "off" if disabled
     #   IPv4 Default: 0.0.0.0
@@ -16,7 +16,7 @@
     # Specifies which port to serve SSL/TLS traffic over, or "off" if disabled
     # See ./conf/ssl/cert.pem and ./conf/ssl/key.pem
     #   Default: off
-    <TLSPort> off </TLSPort>
+    <TLSPort> 443 </TLSPort>
 
     # Enables or disables legacy HTTP versions (HTTP/0.9, HTTP/1.0)
     #   Default: on
@@ -40,7 +40,7 @@
     # Whether or not to pass through requests for PHP files to a PHP-CGI process.
     # If disabled, the value of the WinPHPCGIPath node is ignored.
     #   Default: off
-    <EnablePHPCGI> off </EnablePHPCGI>
+    <EnablePHPCGI> on </EnablePHPCGI>
 
     # NOTE: This node applies to Windows only
     # Points to the php-cgi.exe executable to handle PHP requests on.
@@ -70,15 +70,18 @@
         </Access>
     </Match>
 
+    <Match pattern=".*.html">
+        <Header name="X-Match-Test-Header"> 1 </Header>
+    </Match>
+
     # Controls temporary or permanent redirects for specific files or paths.
     # You can use capture groups like $1 and $2 to reference specific capture groups in the pattern (or $0 for the whole matched string).
     # Note: the "to" attribute is NOT a regular expression, but does support referencing capture groups
     # from the pattern.
     # The example below permanently redirects any HTML files in any directory under /foo/bar to the
     # corresponding HTML file and directory in /baz/qux (see commented-out example below)
-    <!--
-    <Redirect pattern="/foo/bar/(.*?)/(.*?).html" to="/baz/qux/$1/$2.html"> 308 </Redirect>
-    -->
+    <Redirect pattern="^/redirect_from/(.*?)$" to="/redirect_to/$1"> 301 </Redirect>
+    <Redirect pattern="^/redirect_http1.1_only/(.*?)$" to="/redirect_to/$1"> 308 </Redirect>
 
     # Controls whether or not to honor keep-alive headers in requests to maintain
     # a connection that later requests can come through

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -193,15 +193,10 @@ cases = [
     TestCase("DELETE", "/index.php", expected=200, version="1.1"),
     TestCase("POST", "/ASDFGHJKL",   expected=404, version="1.1"),
 
-    # Test PHP path info URIs & URI decoding query strings (HTTP/1.1 ONLY)
+    # Test PHP path info URIs (HTTP/1.1 ONLY)
     TestCase("GET", "/path_info_test.php/foo/bar", expected=200, version="1.1", body_match="/foo/bar"),
     TestCase("GET", "/path_info_test.php/foo/bar?q=1", expected=200, version="1.1", body_match="/foo/bar"),
     TestCase("GET", "/index.html/foo/bar", expected=404, version="1.1"),
-    TestCase("GET", "/%3F/query_string.php/foo/bar?q=1", expected=200, version="1.1", body_match="?q=1"),
-    TestCase("GET", "/%3F/query_string.php/foo/bar", expected=200, version="1.1", body_match=""),
-    TestCase("GET", "/%3F/query_string.php?q=1", expected=200, version="1.1", body_match="?q=1"),
-    TestCase("GET", "/%3F/query_string.php", expected=200, version="1.1", body_match=""),
-    TestCase("GET", "/?/query_string.php", expected=200, version="1.1"),
 
     # Invalid method checking for static files (HTTP/1.1)
     TestCase("GET", "/",            expected=200, version="1.1"),

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -230,7 +230,17 @@ cases = [
     # Test unsupported HTTP methods
     TestCase("HEAD", "/", expected=505, version="2.0"),
     TestCase("HEAD", "/", expected=505, version="3.0"),
-    TestCase("HEAD", "/", expected=505, version="4.0")
+    TestCase("HEAD", "/", expected=505, version="4.0"),
+
+    # Redirect Rule tests
+    TestCase("HEAD", "/redirect_from/foo.txt",         expected=301, version="1.1", expected_headers={"Location": "/redirect_to/foo.txt"}),
+    TestCase("HEAD", "/redirect_from/bar.txt",         expected=301, version="1.0", expected_headers={"Location": "/redirect_to/bar.txt"}),
+    TestCase("HEAD", "/redirect_from/foo.txt",         expected=301, version="1.1", expected_headers={"Location": "/redirect_to/foo.txt"}),
+    TestCase("HEAD", "/redirect_from/bar.txt",         expected=301, version="1.0", expected_headers={"Location": "/redirect_to/bar.txt"}),
+
+    # Test Redirect Rule restriction to 300-302 in HTTP/1.0 (falls back to 302 Found)
+    TestCase("HEAD", "/redirect_http1.1_only/foo.txt", expected=308, version="1.1", expected_headers={"Location": "/redirect_to/foo.txt"}),
+    TestCase("HEAD", "/redirect_http1.1_only/foo.txt", expected=302, version="1.0", expected_headers={"Location": "/redirect_to/foo.txt"})
 ]
 
 # Tests IDENTICAL for HTTP/1.0 and HTTP/1.1
@@ -285,4 +295,12 @@ for ver in ["1.0", "1.1"]:
         # Keep-alive tests
         TestCase("HEAD", "/", expected=200, version=ver, keep_alive=True, expected_headers={"Keep-Alive": None}),
         TestCase("HEAD", "/", expected=200, version=ver, keep_alive=False, expected_headers={"Keep-Alive": False})
+    ])
+
+# Tests IDENTICAL for all versions
+for ver in ["0.9", "1.0", "1.1"]:
+    cases.extend([
+        # Match node pattern tests
+        TestCase("GET", "/index.php", expected=200, version=ver, expected_headers={"X-Match-Test-Header": False}),
+        TestCase("GET", "/index.html", expected=200, version=ver, expected_headers={"X-Match-Test-Header": "1"})
     ])

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -193,9 +193,15 @@ cases = [
     TestCase("DELETE", "/index.php", expected=200, version="1.1"),
     TestCase("POST", "/ASDFGHJKL",   expected=404, version="1.1"),
 
-    # Test PHP path info URIs
+    # Test PHP path info URIs & URI decoding query strings (HTTP/1.1 ONLY)
     TestCase("GET", "/path_info_test.php/foo/bar", expected=200, version="1.1", body_match="/foo/bar"),
+    TestCase("GET", "/path_info_test.php/foo/bar?q=1", expected=200, version="1.1", body_match="/foo/bar"),
     TestCase("GET", "/index.html/foo/bar", expected=404, version="1.1"),
+    TestCase("GET", "/%3F/query_string.php/foo/bar?q=1", expected=200, version="1.1", body_match="?q=1"),
+    TestCase("GET", "/%3F/query_string.php/foo/bar", expected=200, version="1.1", body_match=""),
+    TestCase("GET", "/%3F/query_string.php?q=1", expected=200, version="1.1", body_match="?q=1"),
+    TestCase("GET", "/%3F/query_string.php", expected=200, version="1.1", body_match=""),
+    TestCase("GET", "/?/query_string.php", expected=200, version="1.1"),
 
     # Invalid method checking for static files (HTTP/1.1)
     TestCase("GET", "/",            expected=200, version="1.1"),

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.22.2
+Mercury v0.23.0


### PR DESCRIPTION
## About
I've fixed a number of bugs in this release ranging from small to severe. For one, Match nodes previously failed to load pages if they did not include an Access node, which I have since fixed. I also fixed a bug where if a request had a URI decoded question mark (%3F), it would greatly interfere with query string parsing (particularly for Match & Redirect nodes but also in general) (#246).

I've also fixed the alignment of the CLI table in the README (#240), and for the largest feature of this draft I've added Redirect nodes for redirecting traffic with 3xx status codes (#170).

Here is the drafted changelog:

## v0.23.0
- Justified CLI table in README (#240)
- Updated Performance section in README to include what version was tested
- Add config controls for keep-alive connections & minimum response body size for compression (#237)
- Add Redirect node in config file (#170)
    - See example attached in /conf/default/mercury.conf
- Fixed Match node pattern lookups (previously was comparing empty strings)
- Fixed Match nodes requiring Access nodes within them
    - Was dereferencing a nullptr :(
- Access logs now include the raw incoming path instead of the parsed path
- Fixed URI-encoded question marks breaking query string parsing in Match (and the new Redirect) nodes (#246)