### PR TITLE
[Repo] Reduced Extra Build & Test Calls for Release Maker Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,14 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: mercury-binaries
+          name: mercury-binaries-${{ github.sha }}
           path: ./bin
 
       # Upload static libs
       - name: Upload Static Libraries for workflow_call
         uses: actions/upload-artifact@v4
         with:
-          name: static-libs
+          name: static-libs-${{ github.sha }}
           path: ./libs
 
   Run-Linux-Tests:

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -7,7 +7,39 @@ permissions:
   contents: write
 
 jobs:
+  check-artifacts:
+    runs-on: ubuntu-24.04
+    outputs:
+      found: ${{ steps.check.outputs.found }}
+    steps:
+      - name: Attempt to Download Latest Mercury Binaries
+        id: binaries
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: mercury-binaries-${{ github.sha }}
+          path: ./bin
+
+      - name: Attempt to Download Static Libs
+        id: libs
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: static-libs-${{ github.sha }}
+          path: ./libs
+
+      - name: Confirm Both Artifacts Exist
+        id: check
+        run: |
+          if [ -d "./bin" ] && [ -d "./libs" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
+
   build:
+    needs: check-artifacts
+    if: needs.check-artifacts.outputs.found == 'false'
     uses: ./.github/workflows/build.yml
 
   release:
@@ -26,15 +58,19 @@ jobs:
           git config user.email "mercury-release-workflow@users.noreply.github.com"
 
       # Download binaries
-      - uses: actions/download-artifact@v4
+      - name: Download Binaries (If Rebuilt)
+        if: needs.check-artifacts.outputs.found == 'false'
+        uses: actions/download-artifact@v4
         with:
-          name: mercury-binaries
+          name: mercury-binaries-${{ github.sha }}
           path: ./bin
 
       # Download static libs
-      - uses: actions/download-artifact@v4
+      - name: Download Libs (If Rebuilt)
+        uses: actions/download-artifact@v4
+        if: needs.check-artifacts.outputs.found == 'false'
         with:
-          name: static-libs
+          name: static-libs-${{ github.sha }}
           path: ./libs
 
       # Make executables


### PR DESCRIPTION
## About
It occurred to me that running the Release Maker workflow right after the Build & Test workflow auto-completes from merges to main means running Build & Test twice for the same commit to main. I've updated both of these workflows to upload the binaries keyed with the current commit hash so that if they already exist, the Release Maker can download them for the latest commit and move onward much, much faster.