### PR TITLE
[Repo] Enable Cross-OS Actions Caches for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           path: ./bin
           key: mercury-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
 
       # Mark artifacts for caching
       - name: Cache Library Artifacts

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: ./bin
           key: mercury-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
 
       - name: Try restoring cached libs
         id: lib-cache
@@ -63,6 +64,7 @@ jobs:
         with:
           path: ./bin
           key: mercury-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
 
       - name: Restore Cached Libs
         uses: actions/cache@v4

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           path: ./bin
           key: mercury-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
 
       - name: Copy Default Config
         run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           path: ./bin
           key: mercury-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
 
       - name: Copy Default Config
         run: |


### PR DESCRIPTION
## About
I've updated the workflows to use cross-OS caches for the Windows binaries of Mercury.