### PR TITLE
[Repo] Update Actions to Use actions/checkout@v5 (#254)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   Build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Cache build outputs by commit hash
       - name: Cache Linux Binaries (Overwritten by Make -B Don't Worry)

--- a/.github/workflows/docs-minify-validate.yml
+++ b/.github/workflows/docs-minify-validate.yml
@@ -14,7 +14,7 @@ jobs:
   Minify-Validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install deps
       - run: |

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       hit: ${{ steps.check.outputs.hit }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Linux Binaries
         uses: actions/cache@v4
@@ -53,7 +53,7 @@ jobs:
     if: ${{ always() }} # Run even if cache hits
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.MERCURY_PAT }}
           fetch-depth: 0

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -11,7 +11,7 @@ jobs:
   Test-Linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Download binaries
       - name: Cache Linux Binaries

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,7 +11,7 @@ jobs:
   Test-Windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Download binaries
       - name: Cache Windows Binaries


### PR DESCRIPTION
## About
I've updated all GitHub Actions workflows to use actions/checkout@v5 instead of checkout@v4 which is now outdated.