### PR TITLE
[Repo] Require PRs to Have Matching Changelog & version.txt Versions (#259)

### DIFF
--- a/.github/workflows/compare-changelog-version.yml
+++ b/.github/workflows/compare-changelog-version.yml
@@ -1,0 +1,22 @@
+name: Compare Changelog Version
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  Compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Compare Changelog Version With version.txt
+        run: |
+          CHANGELOG_VERSION=$( cat CHANGELOG.md | grep -Po "(?<=^## )v\d+\.\d+\.\d+$" | head -1 )
+          STORED_VERSION=$( cat version.txt | grep -Po "(?<=^Mercury )v\d+\.\d+\.\d+$" | head -1 )
+
+          if [ "$CHANGELOG_VERSION" != "$STORED_VERSION" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## About
This PR adds a workflow that will apply to all PRs opened to make sure that the latest version in the changelog matches version.txt to prevent accidentally making changes for a new version w/o updating version.txt.