### PR TITLE
[Repo] Restrict Release Maker Action to Main

### DIFF
--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -8,16 +8,11 @@ permissions:
 
 jobs:
   check-cache:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     outputs:
       hit: ${{ steps.check.outputs.hit }}
     steps:
-      - name: Restrict Usage to Main Branch
-        if: github.ref != 'refs/heads/main'
-        run: |
-          echo "❌ This workflow can only run on the 'main' branch."
-          exit 1
-
       - uses: actions/checkout@v5
 
       - name: Restore Linux Binaries
@@ -51,12 +46,12 @@ jobs:
 
   build:
     needs: check-cache
-    if: needs.check-cache.outputs.hit == 'false'
+    if: github.ref == 'refs/heads/main' && needs.check-cache.outputs.hit == 'false'
     uses: ./.github/workflows/build.yml
 
   release:
     needs: build
-    if: ${{ always() }} # Run even if cache hits
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## About
Per #313, I've updated the release maker workflow to skip all jobs if not running on the main branch. Rather than have it fail the job, skipping them seems more appropriate.