### PR TITLE
[Bug] Fix Release Maker Workflow Permission Missing

### DIFF
--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   check-cache:


### PR DESCRIPTION
## About
The release-maker workflow was missing the pull-request: write permission, this PR fixes this.