### PR TITLE
[Bug] Remove `persist-credentials` From Workflows

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -33,7 +33,6 @@ jobs:
         if: ${{ steps.version.outputs.deps_changed != 'None' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           # Create branch & commit
           git checkout -b auto-deps-update-${{ github.run_id }}
@@ -45,7 +44,6 @@ jobs:
         if: ${{ steps.version.outputs.deps_changed != 'None' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           PR_BODY=$( echo -e "Automated dependencies bump for ${{ steps.version.outputs.deps_changed }}.\n\n**NOTE**: Manual CHANGELOG.md and version.txt updates are required." )
 

--- a/.github/workflows/docs-minify-validate.yml
+++ b/.github/workflows/docs-minify-validate.yml
@@ -53,7 +53,6 @@ jobs:
       - if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           git config user.name "Mercury Actions Bot"
           git config user.email "mercury-actions-bot[bot]@users.noreply.github.com"

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -79,7 +79,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
           fetch-depth: 0
           ref: main
 
@@ -143,7 +142,6 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -166,7 +164,6 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           SUMMARY_FILE=$(ls ./releases/SUMMARY_*.md | head -n1)
@@ -190,9 +187,9 @@ jobs:
       - name: Create Release Update Branch
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           # Create branch & commit
+          git remote add origin https://{username}:{password}@github.com/{username}/project.git
           git checkout -b release-update-${{ steps.version.outputs.version }}
           git add docs/releases.json docs/latest
           git commit -m "Update release metadata for ${{ steps.version.outputs.version }}" || echo "No changes to commit"
@@ -202,7 +199,6 @@ jobs:
       - name: Create PR
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           gh pr create \
             --title "[Website] Bump Release ${{ steps.version.outputs.version }}" \
@@ -214,7 +210,6 @@ jobs:
       - name: Approve and Merge PR
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           PR_NUMBER=$(gh pr list --head release-update-${{ steps.version.outputs.version }} --json number -q '.[0].number')
           gh pr merge $PR_NUMBER --merge --admin
@@ -222,7 +217,6 @@ jobs:
       - name: Delete Release Update Branch
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
         run: |
           BRANCH="release-update-${{ steps.version.outputs.version }}"
           git push origin --delete "$BRANCH" || echo "Branch already deleted"


### PR DESCRIPTION
## About
Still testing the Mercury Actions Bot. Removing persist-credentials since the token created is already temporary.