### PR TITLE
[Feature] Add "phpinit" and "status" CLI Commands (Draft v0.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.27.0
 - Added "status" command as an alias for "info" (#357)
+- Added "phpinit" CLI command (#357)
+    - Works for Windows and Linux
+        - Invokes conf/setup_php.ps1 from the program on Windows
+        - Runs `sudo apt install php-cgi` on Linux
 
 ## v0.26.0
 - Add CONFIG.md for config file documentation (#305)

--- a/README.md
+++ b/README.md
@@ -121,9 +121,7 @@ The error log contains any detailed error messages that the server encounters.
 
 PHP is now supported via php-cgi for Windows and Linux!
 
-To install:
-- For Linux, run `sudo apt install php-cgi`.
-- For Windows, run `conf/setup_php.ps1`.
+To install, start Mercury and run the `phpinit` command.
 
 Developer environments also come with php-cgi installed after running `make lib_deps` or `make libs`.
 

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -1,0 +1,84 @@
+#include <atomic>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "conf/conf.hpp"
+#include "http/server.hpp"
+
+void handleCLICommands(const std::string& buf, std::atomic<bool>& isExiting, std::vector<std::shared_ptr<http::Server>>& serversVec) {
+    // Clean exit
+    if (buf == "EXIT") {
+        isExiting.store(true);
+    } else if (buf == "INFO" || buf == "STATUS") {
+        // Print usage info
+        size_t usedThreads = 0, totalThreads = 0, pendingConnections = 0;
+        for (auto& pServer : serversVec)
+            pServer->getUsageInfo(usedThreads, totalThreads, pendingConnections);
+
+        std::cout << std::fixed << std::setprecision(1) << "> "
+            << std::min(static_cast<double>(usedThreads) / totalThreads * 100, 100.0) << "% usage ("
+            << usedThreads << '/' << totalThreads << " threads, " << pendingConnections << " pending connections)"
+            << std::endl;
+    } else if (buf == "PING") {
+        std::cout << "> Pong!" << std::endl;
+    } else if (buf == "HELP") {
+        std::cout << "> Exit: Exit Mercury\n"
+            "  Help: List available commands\n"
+            "  Info: View current utilization\n"
+            "  PHPInit: Initializes platform-specific PHP\n"
+            "  Ping: ???\n"
+            "  Status: View current utilization"
+            << std::endl;
+    } else if (buf == "PHPINIT") {
+        #ifdef _WIN32 // Windows specific
+            std::cout << "> Running `conf/setup_php.ps1`" << std::endl;
+            std::string scriptPath;
+            try {
+                scriptPath = resolveCanonicalPath("conf/setup_php.ps1").string();
+            } catch (...) {
+                std::cout << "> Failed to canonicalize the path to `conf/setup_php.ps1`" << std::endl;
+                return;
+            }
+
+            // Generate command
+            const std::string cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"" + scriptPath + "\"";
+            int rc = -1;
+            STARTUPINFOA si;
+            ZeroMemory(&si, sizeof(si));
+            si.cb = sizeof(si);
+            PROCESS_INFORMATION pi;
+            ZeroMemory(&pi, sizeof(pi));
+
+            // Invoke CreateProcess
+            std::vector<char> cmdLine(cmd.begin(), cmd.end());
+            cmdLine.push_back('\0');
+
+            if (CreateProcessA( NULL, cmdLine.data(), NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi )) {
+                // Wait for process to finish
+                WaitForSingleObject(pi.hProcess, INFINITE);
+
+                DWORD exitCode = 0;
+                rc = GetExitCodeProcess(pi.hProcess, &exitCode) ? static_cast<int>(exitCode) : -1;
+
+                CloseHandle(pi.hProcess); CloseHandle(pi.hThread);
+            } else {
+                // Failed to create process
+                rc = static_cast<int>(GetLastError());
+            }
+        #else // Linux specific
+            std::cout << "> Running `sudo apt install php-cgi -y`" << std::endl;
+            const int rc = std::system("sudo apt install php-cgi -y");
+        #endif
+
+        if (rc == 0) {
+            std::cout << "> PHP initialized successfully." << std::endl;
+            if (!conf::IS_PHP_ENABLED)
+                std::cout << "PHP is currently disabled, set EnablePHPCGI to `on` in your mercury.conf and restart Mercury for these changes to take effect." << std::endl;
+        } else {
+            std::cout << "> Failed to initialize PHP, exited with code " << rc << std::endl;
+        }
+    } else if (!isExiting) {
+        std::cout << "> Unknown command, try \"help\"" << std::endl;
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,9 +5,12 @@
 #include "conf/conf.hpp"
 #include "http/server.hpp"
 #include "http/server-ipv6.hpp"
+#include "io/file_tools.hpp"
 #include "logs/logger.hpp"
 #include "http/version_checker.hpp"
 #include "util/string_tools.hpp"
+
+#include "cli.hpp"
 
 #define SLEEP_BETWEEN_CLI std::this_thread::sleep_for(std::chrono::milliseconds(200))
 
@@ -83,30 +86,7 @@ void awaitCLI() {
         return;
     }
 
-    // Clean exit
-    if (buf == "EXIT") {
-        isExiting.store(true);
-    } else if (buf == "INFO" || buf == "STATUS") {
-        // Print usage info
-        size_t usedThreads = 0, totalThreads = 0, pendingConnections = 0;
-        for (auto& pServer : serversVec)
-            pServer->getUsageInfo(usedThreads, totalThreads, pendingConnections);
-
-        std::cout << std::fixed << std::setprecision(1) << "> "
-            << std::min(static_cast<double>(usedThreads) / totalThreads * 100, 100.0) << "% usage ("
-            << usedThreads << '/' << totalThreads << " threads, " << pendingConnections << " pending connections)"
-            << std::endl;
-    } else if (buf == "PING") {
-        std::cout << "> Pong!" << std::endl;
-    } else if (buf == "HELP") {
-        std::cout << "> Exit: Exit Mercury\n"
-            "  Help: List available commands\n"
-            "  Info: View current utilization\n"
-            "  Ping: ???"
-            << std::endl;
-    } else if (!isExiting) {
-        std::cout << "> Unknown command, try \"help\"" << std::endl;
-    }
+    handleCLICommands(buf, isExiting, serversVec);
 }
 
 /******************** WELCOME BANNER METHODS ********************/

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.26.0
+Mercury v0.27.0


### PR DESCRIPTION
## About
A minor feature update, I've added the "phpinit" and "status" CLI commands, per #357.

## v0.27.0
- Added "status" command as an alias for "info" (#357)
- Added "phpinit" CLI command (#357)
    - Works for Windows and Linux
        - Invokes conf/setup_php.ps1 from the program on Windows
        - Runs `sudo apt install php-cgi` on Linux