### PR TITLE
[Feature] Added Checks for Invalid Config Nodes (Draft v0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.29.0
+- Added checks for invalid config nodes (#363)
+
 ## v0.28.5
 - Correct minor inconsistency with license naming
     - Zstandard License -> BSD License in CREDITS.md

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.28.5
+Mercury v0.29.0


### PR DESCRIPTION
## About
I've added checks per #363 to exit the program if there are any invalid node names in the config file. These are checked before actually parsing the config file.

## v0.29.0
- Added checks for invalid config nodes (#363)