### PR TITLE
[Docs] Bump Copyright Year (Draft v0.29.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.29.4
+- Bump copyright year
+
 ## v0.29.3
 - Added Fedora Linux support
 - Reworked static binaries

--- a/build_tools/install_deps.sh
+++ b/build_tools/install_deps.sh
@@ -43,11 +43,6 @@ case "$PKG_MGR" in
             python3 python3-brotli python3-zstandard python3-psutil \
             php-cgi 1>/dev/null
         ;;
-    # Not implemented yet
-    # yum)
-    #     sudo yum makecache -y 1>/dev/null
-    #     sudo yum install -y $PKGS 1>/dev/null
-    #     ;;
     *)
         echo "Unknown package manager: $PKG_MGR" >&2
         exit 1

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.29.3
+Mercury v0.29.4


### PR DESCRIPTION
## About
I was going to implement support for the `yum` package manager, but since it's all largely deprecated and mirrors are shutting down, I've abandoned it. All hail `dnf`.

PS: I've also updated the copyright year--happy new year!

Closes #372