### PR TITLE
[Bug] Fix `python3-zstandard` Package in Release Maker Workflow

### DIFF
--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -68,7 +68,7 @@ jobs:
         needs.check-cache.outputs.hit == 'true' ||
         always() && needs.build.result == 'success'
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04 # <--- Use 24.04 instead of 22.04 since python3-zstandard does not have a mirror
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token


### PR DESCRIPTION
## About
Patch python3-zstandard package missing mirror on Ubuntu 22.04 in release maker workflow.