### PR TITLE
[Docs] CLI Help List Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Mercury exposes a CLI to the user with the following commands:
 | info    | View current utilization    |
 | phpinit | Downloads & configures PHP  |
 | ping    | ???                         |
-| status  | View current utilization    |
+| status  | See "info"                  |
 
 ### Troubleshooting
 

--- a/src/util/cli.cpp
+++ b/src/util/cli.cpp
@@ -151,7 +151,7 @@ void handleCLICommands(const std::string& buf, std::atomic<bool>& isExiting, std
             "  Info: View current utilization\n"
             "  PHPInit: Initializes platform-specific PHP\n"
             "  Ping: ???\n"
-            "  Status: View current utilization"
+            "  Status: See \"info\""
             << std::endl;
     } else if (buf == "PHPINIT") {
         #ifdef _WIN32 // Windows specific


### PR DESCRIPTION
## About
Minor revision to the CLI help information, rewrote the `status` tip to say `See "info"` instead of explicitly duplicating the tip from `info`.