### PR TITLE
[Feature] Prevent Null Bytes in Paths (Draft-v0.31.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.31.3
+- Improved resilience to path attacks
+    - Now rejects requests with URI-encoded null bytes (%00 and %2500)
+
 ## v0.31.2
 - Now properly closes connections on HTTP/0.9 connections in the event of an error
     - Previously would send an error page HTML response

--- a/src/util/string_tools.cpp
+++ b/src/util/string_tools.cpp
@@ -50,6 +50,11 @@ void decodeURI(std::string& str) {
     size_t index;
     while ((index = str.find('%')) != std::string::npos) {
         if (index + 2 < str.size()) {
+            // Verify not a null byte (%00)
+            if (str[index + 1] == '0' && str[index + 2] == '0')
+                throw std::invalid_argument("");
+
+            // Decode normally
             str.replace(
                 index, 3, 1,
                 static_cast<unsigned char>(std::stoi(str.substr(index + 1, 2), nullptr, 16))

--- a/tests/conf_files/no-php.conf
+++ b/tests/conf_files/no-php.conf
@@ -1,0 +1,59 @@
+<Mercury>
+    <DocumentRoot> ./tests/files/ </DocumentRoot>
+
+    <BindAddressIPv4> 0.0.0.0 </BindAddressIPv4>
+    <BindAddressIPv6> :: </BindAddressIPv6>
+
+    <Port> 8080 </Port>
+    <TLSPort> 8081 </TLSPort>
+
+    <EnableLegacyHTTPVersions> on </EnableLegacyHTTPVersions>
+
+    <IndexFiles> index.html, index.htm, index.php </IndexFiles>
+
+    <AccessLogFile> ./logs/access.log </AccessLogFile>
+    <ErrorLogFile> ./logs/error.log </ErrorLogFile>
+
+    <ClientSecurityMode> Minimal </ClientSecurityMode>
+    <ClientSecurityIPSalt> fAhGD0OnCe4YhSyx </ClientSecurityIPSalt>
+
+    <EnablePHPCGI> off </EnablePHPCGI>
+    <WinPHPCGIPath> ./php/php-cgi.exe </WinPHPCGIPath>
+
+    <Match pattern=".*">
+        <Header name="Cache-Control"> public, must-revalidate, max-age=300 </Header>
+
+        <ShowDirectoryIndexes> on </ShowDirectoryIndexes>
+
+        <Access mode="deny all">
+            <Allow> 127.0.0.1 </Allow>
+            <Allow> ::1 </Allow>
+        </Access>
+    </Match>
+
+    <Redirect pattern="^/redirect_from/(.*?)$" to="/redirect_to/$1"> 301 </Redirect>
+    <Redirect pattern="^/redirect_http1.1_only/(.*?)$" to="/redirect_to/$1"> 308 </Redirect>
+
+    <KeepAlive> on </KeepAlive>
+    <KeepAliveMaxTimeout> 3 </KeepAliveMaxTimeout>
+    <KeepAliveMaxRequests> 100 </KeepAliveMaxRequests>
+
+    <MaxRequestLineLength> 4096 </MaxRequestLineLength>
+
+    <MaxRequestBacklog> 100 </MaxRequestBacklog>
+
+    <RequestBufferSize> 16384 </RequestBufferSize>
+    <ResponseBufferSize> 16384 </ResponseBufferSize>
+
+    <MaxRequestBody> 268435456 </MaxRequestBody>
+    <MaxResponseBody> 268435456 </MaxResponseBody>
+
+    <MinResponseCompressionSize> 750 </MinResponseCompressionSize>
+
+    <IdleThreadsPerChild> 12 </IdleThreadsPerChild>
+    <MaxThreadsPerChild> 60 </MaxThreadsPerChild>
+
+    <ShowWelcomeBanner> false </ShowWelcomeBanner>
+    <ShowDonationBanner> false </ShowDonationBanner>
+    <StartupCheckLatestRelease> false </StartupCheckLatestRelease>
+</Mercury>

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -39,7 +39,13 @@ class TestCase:
             else:
                 self.headers[ku] = v
 
-        self.headers["HOST"] = "localhost"
+        # Check if Host header is already set
+        if "HOST" not in self.headers:
+            self.headers["HOST"] = "localhost"
+        elif self.headers["HOST"] == "":
+            # Remove Host header if blank (for HTTP/1.1 tests)
+            self.headers.pop("HOST")
+
         self.headers["USER-AGENT"] = "Mercury Test Agent"
 
         if len(self.body) > 0:
@@ -142,7 +148,7 @@ class TestCase:
                         self.inline_desc()
                     )
                     return False
-                elif v is not None and k in headers and headers[k] != v:
+                elif v is not True and k in headers and headers[k] != v:
                     lprint(
                         f"Failed {test_desc}: Header mismatch - expected \"{k}\"=\"{v}\", got \"{k}\"=\"{headers[k]}\"\n",
                         self.inline_desc()

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -33,14 +33,22 @@
             },
 
             {
+                "desc": "Test HTTP/1.1 Required Headers",
+                "versions": [ "1.1" ],
+                "cases": [
+                    { "method": "HEAD", "path": "/", "expectedStatus": 400, "headers": { "Host": "" } }
+                ]
+            },
+
+            {
                 "desc": "Test Invalid Methods (HTTP/1.1)",
                 "versions": [ "1.1" ],
                 "cases": [
                     { "method": "GET", "path": "/", "expectedStatus": 200 },
                     { "method": "HEAD", "path": "/", "expectedStatus": 200 },
                     { "method": "HEAD", "path": "*", "expectedStatus": 400 },
-                    { "method": "OPTIONS", "path": "/", "expectedStatus": 204, "expectedHeaders": {"Allow": null} },
-                    { "method": "OPTIONS", "path": "*", "expectedStatus": 204, "expectedHeaders": {"Allow": null} },
+                    { "method": "OPTIONS", "path": "/", "expectedStatus": 204, "expectedHeaders": {"Allow": true} },
+                    { "method": "OPTIONS", "path": "*", "expectedStatus": 204, "expectedHeaders": {"Allow": true} },
                     { "method": "POST", "path": "/", "expectedStatus": 405 },
                     { "method": "PUT", "path": "/", "expectedStatus": 405 },
                     { "method": "PATCH", "path": "/", "expectedStatus": 405 },
@@ -76,6 +84,8 @@
                 "cases": [
                     { "method": "GET", "path": "/index.html", "expectedStatus": -1, "expectedBody": "Mercury is successfully running on your machine", "expectedBodyContainsMode": true },
                     { "method": "HEAD", "path": "/index.html", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "POST", "path": "/index.html", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "POST", "path": "/asdfkljhasflk", "expectedStatus": -1, "expectedBody": "" },
                     { "method": "GET", "path": "/index.php", "expectedStatus": -1, "expectedBody": "" }
                 ]
             },
@@ -139,6 +149,10 @@
                     { "method": "HEAD", "path": "%252e%252e%255c", "expectedStatus": 400 },
                     { "method": "HEAD", "path": "..%255c", "expectedStatus": 400 },
                     { "method": "HEAD", "path": "/index.html%", "expectedStatus": 400 },
+                    { "method": "HEAD", "path": "%00/index.html", "expectedStatus": 400 },
+                    { "method": "HEAD", "path": "/%00/index.html", "expectedStatus": 400 },
+                    { "method": "HEAD", "path": "/%00", "expectedStatus": 400 },
+                    { "method": "HEAD", "path": "/%2500", "expectedStatus": 400 },
 
                     { "method": "GET", "path": "\\index.html", "expectedStatus": 200 },
                     { "method": "GET", "path": "\\\\index.html", "expectedStatus": 200 },
@@ -168,38 +182,43 @@
                 "desc": "Byte Ranges (HTTP/1.1)",
                 "versions": [ "1.1" ],
                 "cases": [
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-"}, "expectedHeaders": {"Content-Length": "19"}, "expectedBody": "redirect_to/foo.txt" },
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-18"}, "expectedHeaders": {"Content-Length": "19"}, "expectedBody": "redirect_to/foo.txt" },
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=-19"}, "expectedHeaders": {"Content-Length": "19"}, "expectedBody": "redirect_to/foo.txt" },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19"}, "expectedBody": "redirect_to/foo.txt" },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-18"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19"}, "expectedBody": "redirect_to/foo.txt" },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=-19"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19"}, "expectedBody": "redirect_to/foo.txt" },
 
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-", "Accept-Encoding": "gzip"}, "expectedHeaders": {"Content-Length": "19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt" },
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-", "Accept-Encoding": "deflate"}, "expectedHeaders": {"Content-Length": "19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt", "httpsOnly": true },
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-18", "Accept-Encoding": "br"}, "expectedHeaders": {"Content-Length": "19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt" },
-                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=-19", "Accept-Encoding": "zstd"}, "expectedHeaders": {"Content-Length": "19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt" },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-", "Accept-Encoding": "gzip"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt" },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-", "Accept-Encoding": "deflate"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt", "httpsOnly": true },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-18", "Accept-Encoding": "br"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt" },
+                    { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=-19", "Accept-Encoding": "zstd"}, "expectedHeaders": {"Content-Length": "19", "Content-Range": "bytes 0-18/19", "Content-Encoding": false}, "expectedBody": "redirect_to/foo.txt" },
 
                     { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 206, "headers": {"Range": "bytes=0-16", "RANGE": "bytes=17-18"}, "expectedHeaders": {"Content-Length": "19"}, "expectedBody": "redirect_to/foo.txt" },
                     { "method": "GET", "path": "/redirect_to/foo.txt", "expectedStatus": 416, "headers": {"Range": "bytes=0-15", "RANGE": "bytes=17-18"} },
 
                     { "method": "HEAD", "path": "/", "expectedStatus": 206, "headers": {"Range": "bytes=0-13"}, "expectedHeaders": {"Content-Length": "14"} },
                     { "method": "HEAD", "path": "/", "expectedStatus": 206, "headers": {"Range": "bytes=-14"}, "expectedHeaders": {"Content-Length": "14"} },
-                    { "method": "HEAD", "path": "/", "expectedStatus": 206, "headers": {"Range": "bytes=22-"}, "expectedHeaders": {"Content-Length": null} },
+                    { "method": "HEAD", "path": "/", "expectedStatus": 206, "headers": {"Range": "bytes=22-"}, "expectedHeaders": {"Content-Length": true} },
                     { "method": "HEAD", "path": "/", "expectedStatus": 416, "headers": {"Range": "bytes=0-13, -19"} },
+                    { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=foo"}, "expectedHeaders": {"Content-Length": true} },
 
                     { "method": "HEAD", "path": "/index.php", "expectedStatus": 206, "headers": {"Range": "bytes=0-13"}, "expectedHeaders": {"Content-Length": "14"} },
                     { "method": "HEAD", "path": "/index.php", "expectedStatus": 206, "headers": {"Range": "bytes=-14"}, "expectedHeaders": {"Content-Length": "14"} },
-                    { "method": "HEAD", "path": "/index.php", "expectedStatus": 206, "headers": {"Range": "bytes=22-"}, "expectedHeaders": {"Content-Length": null} },
-                    { "method": "HEAD", "path": "/index.php", "expectedStatus": 416, "headers": {"Range": "bytes=0-13, -19"} }
+                    { "method": "HEAD", "path": "/index.php", "expectedStatus": 206, "headers": {"Range": "bytes=22-"}, "expectedHeaders": {"Content-Length": true} },
+
+                    { "method": "HEAD", "path": "/index.php", "expectedStatus": 416, "headers": {"Range": "bytes=0-13, -19"} },
+                    { "method": "HEAD", "path": "/index.php", "expectedStatus": 200, "headers": {"Range": "bytes=foo"}, "expectedHeaders": {"Content-Length": true} }
                 ]
             },
 
             {
                 "desc": "Byte Ranges (HTTP/1.0)",
+                "comments": "Range requests were not introduced until HTTP/1.1",
                 "versions": [ "1.0" ],
                 "cases": [
                     { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=0-13"}, "expectedHeaders": {"Content-Range": false} },
                     { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=-14"}, "expectedHeaders": {"Content-Range": false} },
                     { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=22-"}, "expectedHeaders": {"Content-Range": false} },
-                    { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=0-13, -19"}, "expectedHeaders": {"Content-Range": false} }
+                    { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=0-13, -19"}, "expectedHeaders": {"Content-Range": false} },
+                    { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Range": "bytes=foo"}, "expectedHeaders": {"Content-Length": true} }
                 ]
             },
 
@@ -213,6 +232,9 @@
                     { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Accept": "text/html", "ACCEPT": "text/plain"} },
                     { "method": "HEAD", "path": "/", "expectedStatus": 406, "headers": {"Accept": "foobar;bar,;123"} },
                     { "method": "HEAD", "path": "/", "expectedStatus": 200, "headers": {"Accept": "text/html; charset=UTF-8; foo=bar; q=1"} },
+
+                    { "method": "HEAD", "path": "/A.txt", "expectedStatus": 200, "expectedBody": "" },
+                    { "method": "HEAD", "path": "/index.html", "expectedStatus": 200, "expectedBody": "" },
 
                     { "method": "GET", "path": "/A.txt", "expectedStatus": 200, "expectedHeaders": {"X-Match-Test-Header": false} },
                     { "method": "GET", "path": "/index.html", "expectedStatus": 200, "expectedHeaders": {"X-Match-Test-Header": "1"} }
@@ -443,6 +465,28 @@
                 "cases": [
                     { "method": "HEAD", "path": "/", "expectedStatus": 200 },
                     { "method": "HEAD", "path": "/a", "expectedStatus": 414 }
+                ]
+            }
+        ]
+    },
+    {
+        "desc": "PHP Disabled Tests",
+        "confFile": "no-php.conf",
+        "cases": [
+            {
+                "desc": "HTTP/1.x Tests",
+                "versions": [ "1.0", "1.1" ],
+                "cases": [
+                    { "method": "GET", "path": "/index.php", "expectedStatus": 200 },
+                    { "method": "GET", "path": "/path_info_test.php", "expectedStatus": 200, "expectedBody": "echo $_SERVER[\"PATH_INFO\"];", "expectedBodyContainsMode": true }
+                ]
+            },
+            {
+                "desc": "HTTP/0.9 Tests",
+                "versions": [ "0.9" ],
+                "cases": [
+                    { "method": "GET", "path": "/index.php", "expectedStatus": -1, "expectedBody": "Your Mercury installation is successfully parsing PHP via CGI.", "expectedBodyContainsMode": true },
+                    { "method": "GET", "path": "/path_info_test.php", "expectedStatus": -1, "expectedBody": "echo $_SERVER[\"PATH_INFO\"];", "expectedBodyContainsMode": true }
                 ]
             }
         ]

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -132,7 +132,7 @@
             },
 
             {
-                "desc": "Path Tests & CRLF Injection",
+                "desc": "Path Tests & CRLF Injection (HTTP/1.x)",
                 "versions": [ "1.0", "1.1" ],
                 "cases": [
                     { "method": "HEAD", "path": ".", "expectedStatus": 400 },
@@ -164,6 +164,42 @@
                     { "method": "HEAD", "path": "", "expectedStatus": 400 },
                     { "method": "HEAD", "path": " ", "expectedStatus": 505 },
                     { "method": "HEAD", "path": "?", "expectedStatus": 400 }
+                ]
+            },
+
+            {
+                "desc": "Path Tests & CRLF Injection (HTTP/0.9)",
+                "versions": [ "0.9" ],
+                "cases": [
+                    { "method": "GET", "path": ".", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "../", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "..\\", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "/../", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "\\..\\", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "%2e%2e%2f", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "%2e%2e%5c", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "%2e%2e/", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "%2e%2e\\", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "..%2f", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "..%5c", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "%252e%252e%255c", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "..%255c", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "/index.html%", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "%00/index.html", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "/%00/index.html", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "/%00", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "/%2500", "expectedStatus": -1, "expectedBody": "" },
+
+                    { "method": "GET", "path": "\\index.html", "expectedStatus": -1, "expectedBody": "Mercury is successfully running on your machine.", "expectedBodyContainsMode": true },
+                    { "method": "GET", "path": "\\\\index.html", "expectedStatus": -1, "expectedBody": "Mercury is successfully running on your machine.", "expectedBodyContainsMode": true },
+                    { "method": "GET", "path": "//index.html", "expectedStatus": -1, "expectedBody": "Mercury is successfully running on your machine.", "expectedBodyContainsMode": true },
+
+                    { "method": "GET", "path": "/%0D%0A", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": "/index.html?q=%0D%0A", "expectedStatus": -1, "expectedBody": "Mercury is successfully running on your machine.", "expectedBodyContainsMode": true },
+
+                    { "method": "GET", "path": "", "expectedStatus": -1, "expectedBody": "" },
+                    { "method": "GET", "path": " ", "expectedStatus": -1, "expectedBody": "HTTP/1.1 505 HTTP Version Not Supported", "expectedBodyContainsMode": true },
+                    { "method": "GET", "path": "?", "expectedStatus": -1, "expectedBody": "" }
                 ]
             },
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.31.2
+Mercury v0.31.3


### PR DESCRIPTION
## About
While expanding the test suite, I realized that it was possible to send URI-encoded null bytes (%00 and %2500). I've expanded the test suite to address these edge cases and updated Mercury to be resilient to these attacks.

Among the test suites, I've also added tests for basic spec adherence (e.g. requiring Host header in HTTP/1.1, Range header formatting, tests w/ PHP disabled, checks for Content-Range header in Range requests, and a bit more). In addition, I've added tests for path & URI injection tests on HTTP/0.9 as well as the existing ones for HTTP/1.x.