### PR TITLE
[Docs] Add Collapsible README Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@
 
 ---
 
-## Table of Contents
+<details>
+    <summary>
+        <h2>Table of Contents</h2>
+    </summary>
 
 - [About](#about)
     - [Performance](#performance)
@@ -39,6 +42,8 @@
 - [Credits](#credits)
 - [Fun Facts](#fun-facts)
 - [Support Mercury](#support-mercury)
+
+</details>
 
 ## About
 
@@ -69,7 +74,10 @@ Each value is the average of five separate trials using the Python test cases in
 
 *Actual performance will vary between systems; this data is a baseline.*
 
-## Getting Started
+<details>
+    <summary>
+        <h2>Getting Started</h2>
+    </summary>
 
 Once you've downloaded your own Mercury release, navigate to the `bin/` directory.
 From the terminal, start `mercury` on Linux or `mercury.exe` on Windows.
@@ -191,7 +199,12 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
 
 If you encounter any other issues or unexpected behavior, please consider opening an Issue on the [Mercury GitHub repository](https://github.com/travis-heavener/mercury/issues/new/choose).
 
-## For Developers
+</details>
+
+<details>
+    <summary>
+        <h2>For Developers</h2>
+    </summary>
 
 Currently, the Mercury development environment is only available on Linux environments that support APT, Pacman, or DNF.
 **Windows is not recognized as a development environment and as such the following steps will not work as intended (if at all).**
@@ -284,6 +297,8 @@ Because Docker installation methods vary wildly between Linux distributions, it 
 Refer to the [DockerDocs](https://docs.docker.com/engine/install/) for your specific distro's install guide.
 
 If you have Docker installed, you can use the `make docker_tests` recipe to run the Python test script against a number of Linux distributions.
+
+</details>
 
 ## Privacy Commitment
 

--- a/build_tools/release_readme_maker.py
+++ b/build_tools/release_readme_maker.py
@@ -7,6 +7,15 @@ This file formats the README into a plaintext-compatible version for releases.
 from sys import argv
 import re
 
+def remove_collapsibles(body: str) -> str:
+    body = re.sub( 
+        r"<details>\s*<summary>\s*<h2>(.*?)</h2>\s*</summary>\s*(.*?)\s*</details>",
+        r"## \1\n\n\2",
+        body,
+        flags=re.DOTALL | re.IGNORECASE
+    )
+    return body
+
 def remove_until_section(body: str, header: str) -> str:
     # Find start of section
     start = re.search(rf"^## {header}", body, flags=re.MULTILINE)
@@ -61,6 +70,9 @@ def main(path: str):
     # Read
     with open(path, "r") as f:
         body = f.read()
+
+    # Undo collapsible formatting
+    body = remove_collapsibles(body)
 
     # Replace first section
     body = remove_until_section(body, "Table of Contents")


### PR DESCRIPTION
## About
Per #444, I've added collapsible content sections to the README, which doesn't actually change the output of running `make release` hence why this isn't its own release. The README content itself hasn't changed, just displays more nicely on GitHub.