### PR TITLE
[Repo] Bump Workflow Versions for Deprecated Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   Build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Cache build outputs by commit hash
       - name: Cache Linux Binaries (Overwritten by Make -B Don't Worry)

--- a/.github/workflows/check-copyright-year.yml
+++ b/.github/workflows/check-copyright-year.yml
@@ -10,7 +10,7 @@ jobs:
   Compare:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Compare License Year w/ Current Year
         run: |

--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -16,7 +16,7 @@ jobs:
           app-id: ${{ vars.MERCURY_BOT_APP_ID }}
           private-key: ${{ secrets.MERCURY_BOT_KEY }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set User
         run: |

--- a/.github/workflows/compare-changelog-version.yml
+++ b/.github/workflows/compare-changelog-version.yml
@@ -10,7 +10,7 @@ jobs:
   Compare:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Compare Changelog Version With version.txt
         run: |

--- a/.github/workflows/docs-minify-validate.yml
+++ b/.github/workflows/docs-minify-validate.yml
@@ -20,7 +20,7 @@ jobs:
           app-id: ${{ vars.MERCURY_BOT_APP_ID }}
           private-key: ${{ secrets.MERCURY_BOT_KEY }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Install deps
       - run: |

--- a/.github/workflows/release-maker.yml
+++ b/.github/workflows/release-maker.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       hit: ${{ steps.check.outputs.hit }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Restore Linux Binaries
         uses: actions/cache@v5
@@ -76,7 +76,7 @@ jobs:
           app-id: ${{ vars.MERCURY_BOT_APP_ID }}
           private-key: ${{ secrets.MERCURY_BOT_KEY }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -11,7 +11,7 @@ jobs:
   Test-Linux:
     runs-on: ubuntu-24.04 # <--- Use 24.04 instead of 22.04 since python3-zstandard does not have a mirror
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Download binaries
       - name: Cache Linux Binaries

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,7 +11,7 @@ jobs:
   Test-Windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Download binaries
       - name: Cache Windows Binaries


### PR DESCRIPTION
## About
Currently migrating from deprecated actions using Node 20.

From what I can tell, actions/cache@v5 is still triggering warnings for actions/cache/restore@v4 so I'm leaving this PR drafted till a later date.

Update: replace `app-id` with `client-id`