### PR TITLE
[Bug] Fix Seg. Fault When Fetching Latest Version (Draft-v0.31.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.31.6
+- Fix segmentation fault when fetching latest version w/o active internet connection (#464)
+
 ## v0.31.5
 - Bump OpenSSL to v4.0.0 (#460)
 

--- a/src/http/version_checker.cpp
+++ b/src/http/version_checker.cpp
@@ -25,19 +25,23 @@ std::string fetchLatestVersion() {
 
     // 1. Resolve host
     addrinfo hints{};
-    addrinfo* res;
+    addrinfo* res = nullptr;
 
     hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
 
     if (getaddrinfo(host.c_str(), "443", &hints, &res) != 0) {
-        freeaddrinfo(res);
+        if (res) freeaddrinfo(res);
         return "";
     }
 
     // 2. Create socket
-    int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (sock < 0) return "";
+    const int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (sock < 0) {
+        freeaddrinfo(res);
+        return "";
+    }
+
     if (connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
         close(sock);
         freeaddrinfo(res);
@@ -52,6 +56,7 @@ std::string fetchLatestVersion() {
     SSL_CTX* ctx = SSL_CTX_new(method);
     SSL* ssl = SSL_new(ctx);
     SSL_set_fd(ssl, sock);
+    SSL_set_tlsext_host_name(ssl, host.c_str());
 
     if (SSL_connect(ssl) <= 0) {
         SSL_free(ssl);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,6 +168,8 @@ int main(int argc, char* argv[]) {
         try {
             if (latestVersion.length() > 0 && conf::isVersionOutdated(latestVersion))
                 std::cout << "Update available! (" << latestVersion.substr(8) << ")\nVisit https://wowtravis.com/mercury" << std::endl;
+            else if (latestVersion.length() == 0)
+                std::cerr << "Failed to fetch latest version!" << std::endl;
         } catch (std::invalid_argument&) {
             std::cout << "Failed to compare local and remote versions!" << std::endl;
         }

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Mercury v0.31.5
+Mercury v0.31.6


### PR DESCRIPTION
## About
See #464, when fetching latest version w/o an active internet connection a segmentation fault would occur. I've fixed this issue in v0.31.6, as well as potentially also fixing the SSL hostname handling (I'm guessing due to a change in the latest OpenSSL version).